### PR TITLE
[Feat] index.* 파일을 디렉토리명으로 import 할 수 있도록 변경

### DIFF
--- a/app/frontend/tsconfig.json
+++ b/app/frontend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
+      "@*": ["src/*/index.js", "src/*/index.ts", "src/*/index.jsx", "src/*/index.tsx", "src/*/index.css", "src/*/index.css.ts"],
       "@assets/*": ["src/assets/*"],
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
@@ -14,7 +14,7 @@
       "@styles/*": ["src/styles/*"],
       "@types/*": ["src/types/*"],
       "@utils/*": ["src/utils/*"]
-    }
+    },
   },
   "extends": "@morak/tsconfig/frontend.json",
   "include": ["src"],

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -21,6 +21,6 @@ export default defineConfig({
       { find: '@types', replacement: path.resolve(__dirname, 'src/types') },
       { find: '@utils', replacement: path.resolve(__dirname, 'src/utils') },
     ],
-    extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],
+    extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.css.ts'],
   },
 });


### PR DESCRIPTION
## 설명
close #69 

## 완료한 기능 명세
- index.* 파일을 import 할 경우 파일명을 생략하고 해당 파일이 존재하는 디렉토리명으로 불러올 수 있도록 설정을 변경했습니다.

## 리뷰 요청 사항
- 웬만한 경우의 자동 완성까지 확인했으나 예외가 있을 수 있습니다! 발견하시면 말씀해 주세요.
- 예외적으로 `src/App.tsx` 파일에서는 원인을 알 수 없지만 자동 완성으로 불러오는 파일의 이름이 `index.*`가 아닐 경우 확장자가 붙은 채로 import 됩니다. (다른 곳에서 불러올 때에는 확장자가 정상적으로 제외됩니다)