### PR TITLE
[Feat] Modal 컴포넌트 구현

### DIFF
--- a/app/frontend/src/components/commons/Button/index.tsx
+++ b/app/frontend/src/components/commons/Button/index.tsx
@@ -7,7 +7,7 @@ type ButtonProps = {
   size: 'small' | 'medium' | 'large';
   disabled?: boolean;
   fullWidth?: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   children: React.ReactNode;
 };
 

--- a/app/frontend/src/components/commons/Input/index.css.ts
+++ b/app/frontend/src/components/commons/Input/index.css.ts
@@ -11,11 +11,11 @@ export const container = style({
 export const count = style([
   fontStyle.sansRegular12,
   {
-    display: 'none',
+    visibility: 'hidden',
 
     selectors: {
       [`${container}:focus-within &`]: {
-        display: 'block',
+        visibility: 'visible',
       },
     },
   },

--- a/app/frontend/src/components/commons/Input/index.tsx
+++ b/app/frontend/src/components/commons/Input/index.tsx
@@ -3,17 +3,17 @@ import { HTMLInputTypeAttribute } from 'react';
 import * as styles from './index.css';
 
 type InputProps = {
-  label: string;
-  maxLength: number;
+  label?: string;
   placeholder?: string;
   errorMessage?: string;
   type?: HTMLInputTypeAttribute;
   disabled?: boolean;
+  maxLength: number;
   required?: boolean;
 };
 
 export function Input({
-  label,
+  label = '',
   type = 'input',
   placeholder = '',
   errorMessage = '',

--- a/app/frontend/src/components/commons/Modal/Footer.tsx
+++ b/app/frontend/src/components/commons/Modal/Footer.tsx
@@ -3,8 +3,8 @@ import { Button } from '../Button';
 
 type FooterProps = {
   buttonType: 'single' | 'double';
-  confirmButtonText?: string;
-  cancelButtonText?: string;
+  confirmButtonText: string;
+  cancelButtonText: string;
   onClickConfirm: () => void;
 };
 

--- a/app/frontend/src/components/commons/Modal/Footer.tsx
+++ b/app/frontend/src/components/commons/Modal/Footer.tsx
@@ -1,0 +1,31 @@
+import * as styles from './index.css';
+import { Button } from '../Button';
+
+type FooterProps = {
+  buttonType: 'single' | 'double';
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onClickConfirm: () => void;
+};
+
+export function Footer({ buttonType, confirmButtonText, cancelButtonText, onClickConfirm }: FooterProps) {
+  return (
+    <div className={styles.buttonArea}>
+      <Button
+        type="button"
+        theme="primary"
+        shape="fill"
+        size="large"
+        fullWidth
+        onClick={buttonType === 'double' ? onClickConfirm : undefined}
+      >
+        {confirmButtonText}
+      </Button>
+      {buttonType === 'double' && (
+        <Button type="button" theme="primary" shape="line" size="large" fullWidth>
+          {cancelButtonText}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/commons/Modal/Footer.tsx
+++ b/app/frontend/src/components/commons/Modal/Footer.tsx
@@ -5,10 +5,16 @@ type FooterProps = {
   buttonType: 'single' | 'double';
   confirmButtonText: string;
   cancelButtonText: string;
+  closeModal: () => void;
   onClickConfirm: () => void;
 };
 
-export function Footer({ buttonType, confirmButtonText, cancelButtonText, onClickConfirm }: FooterProps) {
+export function Footer({ buttonType, confirmButtonText, cancelButtonText, closeModal, onClickConfirm }: FooterProps) {
+  const confirmModal = () => {
+    onClickConfirm();
+    closeModal();
+  };
+
   return (
     <div className={styles.buttonArea}>
       <Button
@@ -17,12 +23,12 @@ export function Footer({ buttonType, confirmButtonText, cancelButtonText, onClic
         shape="fill"
         size="large"
         fullWidth
-        onClick={buttonType === 'double' ? onClickConfirm : undefined}
+        onClick={buttonType === 'double' ? confirmModal : closeModal}
       >
         {confirmButtonText}
       </Button>
       {buttonType === 'double' && (
-        <Button type="button" theme="primary" shape="line" size="large" fullWidth>
+        <Button type="button" theme="primary" shape="line" size="large" fullWidth onClick={closeModal}>
           {cancelButtonText}
         </Button>
       )}

--- a/app/frontend/src/components/commons/Modal/InputModal.tsx
+++ b/app/frontend/src/components/commons/Modal/InputModal.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/commons/Button';
+import { Input } from '@/components/commons/Input';
+import { sansRegular16 } from '@/styles/font.css';
+
+import * as styles from './index.css';
+
+type InputModalProps = {
+  description: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onClickConfirm: () => void;
+};
+
+export function InputModal({
+  description,
+  confirmButtonText = '확인',
+  cancelButtonText = '취소',
+  onClickConfirm,
+}: InputModalProps) {
+  return (
+    <dialog className={styles.container}>
+      <div className={styles.inputArea}>
+        <div className={sansRegular16}>{description}</div>
+        <Input maxLength={10} />
+      </div>
+      <div className={styles.buttonArea}>
+        <Button type="button" theme="primary" shape="fill" size="large" fullWidth onClick={onClickConfirm}>
+          {confirmButtonText}
+        </Button>
+        <Button type="button" theme="primary" shape="line" size="large" fullWidth>
+          {cancelButtonText}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/app/frontend/src/components/commons/Modal/InputModal.tsx
+++ b/app/frontend/src/components/commons/Modal/InputModal.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/commons/Button';
 import { Input } from '@/components/commons/Input';
 import { sansRegular16 } from '@/styles/font.css';
 
+import { Footer } from './Footer';
 import * as styles from './index.css';
 
 type InputModalProps = {
@@ -25,14 +25,12 @@ export function InputModal({
           <div className={sansRegular16}>{description}</div>
           <Input maxLength={10} />
         </div>
-        <div className={styles.buttonArea}>
-          <Button type="button" theme="primary" shape="fill" size="large" fullWidth onClick={onClickConfirm}>
-            {confirmButtonText}
-          </Button>
-          <Button type="button" theme="primary" shape="line" size="large" fullWidth>
-            {cancelButtonText}
-          </Button>
-        </div>
+        <Footer
+          buttonType="double"
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          onClickConfirm={onClickConfirm}
+        />
       </dialog>
     </>
   );

--- a/app/frontend/src/components/commons/Modal/InputModal.tsx
+++ b/app/frontend/src/components/commons/Modal/InputModal.tsx
@@ -5,6 +5,7 @@ import { Footer } from './Footer';
 import * as styles from './index.css';
 
 type InputModalProps = {
+  dialogRef: React.RefObject<HTMLDialogElement>;
   description: string;
   confirmButtonText?: string;
   cancelButtonText?: string;
@@ -12,26 +13,30 @@ type InputModalProps = {
 };
 
 export function InputModal({
+  dialogRef,
   description,
   confirmButtonText = '확인',
   cancelButtonText = '취소',
   onClickConfirm,
 }: InputModalProps) {
+  const closeModal = () => {
+    if (!dialogRef.current) return;
+    dialogRef.current.close();
+  };
+
   return (
-    <>
-      <div className={styles.background} />
-      <dialog className={styles.container}>
-        <div className={styles.inputArea}>
-          <div className={sansRegular16}>{description}</div>
-          <Input maxLength={10} />
-        </div>
-        <Footer
-          buttonType="double"
-          confirmButtonText={confirmButtonText}
-          cancelButtonText={cancelButtonText}
-          onClickConfirm={onClickConfirm}
-        />
-      </dialog>
-    </>
+    <dialog className={styles.container} ref={dialogRef}>
+      <div className={styles.inputArea}>
+        <div className={sansRegular16}>{description}</div>
+        <Input maxLength={10} />
+      </div>
+      <Footer
+        buttonType="double"
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
+        closeModal={closeModal}
+        onClickConfirm={onClickConfirm}
+      />
+    </dialog>
   );
 }

--- a/app/frontend/src/components/commons/Modal/InputModal.tsx
+++ b/app/frontend/src/components/commons/Modal/InputModal.tsx
@@ -18,19 +18,22 @@ export function InputModal({
   onClickConfirm,
 }: InputModalProps) {
   return (
-    <dialog className={styles.container}>
-      <div className={styles.inputArea}>
-        <div className={sansRegular16}>{description}</div>
-        <Input maxLength={10} />
-      </div>
-      <div className={styles.buttonArea}>
-        <Button type="button" theme="primary" shape="fill" size="large" fullWidth onClick={onClickConfirm}>
-          {confirmButtonText}
-        </Button>
-        <Button type="button" theme="primary" shape="line" size="large" fullWidth>
-          {cancelButtonText}
-        </Button>
-      </div>
-    </dialog>
+    <>
+      <div className={styles.background} />
+      <dialog className={styles.container}>
+        <div className={styles.inputArea}>
+          <div className={sansRegular16}>{description}</div>
+          <Input maxLength={10} />
+        </div>
+        <div className={styles.buttonArea}>
+          <Button type="button" theme="primary" shape="fill" size="large" fullWidth onClick={onClickConfirm}>
+            {confirmButtonText}
+          </Button>
+          <Button type="button" theme="primary" shape="line" size="large" fullWidth>
+            {cancelButtonText}
+          </Button>
+        </div>
+      </dialog>
+    </>
   );
 }

--- a/app/frontend/src/components/commons/Modal/index.css.ts
+++ b/app/frontend/src/components/commons/Modal/index.css.ts
@@ -1,13 +1,23 @@
 import { style } from '@vanilla-extract/css';
 
+export const buttonArea = style({
+  display: 'flex',
+  justifyContent: 'stretch',
+  gap: '1.6rem',
+});
+
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
-  minWidth: '32rem',
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
   minHeight: '20rem',
-  border: 'none',
+  minWidth: '32rem',
+  padding: '1.6rem',
   borderRadius: '0.8rem',
   boxShadow: '0 0.4rem 0.8rem rgba(0, 0, 0, 0.25)',
+  transform: 'translate(-50%, -50%)',
 });
 
 export const textArea = style({
@@ -15,24 +25,6 @@ export const textArea = style({
   flexDirection: 'column',
   flexGrow: 1,
   justifyContent: 'center',
+  alignItems: 'center',
   gap: '0.8rem',
-});
-
-export const title = style({
-  fontSize: '2.4rem',
-});
-
-export const content = style({
-  fontSize: '1.6rem',
-});
-
-export const buttonArea = style({
-  display: 'flex',
-  justifyContent: 'stretch',
-  gap: '1.6rem',
-});
-
-export const button = style({
-  width: '100%',
-  fontSize: '1.6rem',
 });

--- a/app/frontend/src/components/commons/Modal/index.css.ts
+++ b/app/frontend/src/components/commons/Modal/index.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: '32rem',
+  minHeight: '20rem',
+  border: 'none',
+  borderRadius: '0.8rem',
+  boxShadow: '0 0.4rem 0.8rem rgba(0, 0, 0, 0.25)',
+});
+
+export const textArea = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  justifyContent: 'center',
+  gap: '0.8rem',
+});
+
+export const title = style({
+  fontSize: '2.4rem',
+});
+
+export const content = style({
+  fontSize: '1.6rem',
+});
+
+export const buttonArea = style({
+  display: 'flex',
+  justifyContent: 'stretch',
+  gap: '1.6rem',
+});
+
+export const button = style({
+  width: '100%',
+  fontSize: '1.6rem',
+});

--- a/app/frontend/src/components/commons/Modal/index.css.ts
+++ b/app/frontend/src/components/commons/Modal/index.css.ts
@@ -1,5 +1,15 @@
 import { style } from '@vanilla-extract/css';
 
+export const background = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  background: 'rgba(14, 31, 24, 0.05)',
+  backdropFilter: 'blur(0.1rem)',
+});
+
 export const buttonArea = style({
   display: 'flex',
   justifyContent: 'stretch',
@@ -18,6 +28,14 @@ export const container = style({
   borderRadius: '0.8rem',
   boxShadow: '0 0.4rem 0.8rem rgba(0, 0, 0, 0.25)',
   transform: 'translate(-50%, -50%)',
+});
+
+export const inputArea = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  gap: '0.8rem',
+  flexGrow: 1,
 });
 
 export const textArea = style({

--- a/app/frontend/src/components/commons/Modal/index.css.ts
+++ b/app/frontend/src/components/commons/Modal/index.css.ts
@@ -1,15 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-export const background = style({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  width: '100%',
-  height: '100%',
-  background: 'rgba(14, 31, 24, 0.05)',
-  backdropFilter: 'blur(0.1rem)',
-});
-
 export const buttonArea = style({
   display: 'flex',
   justifyContent: 'stretch',
@@ -17,7 +7,7 @@ export const buttonArea = style({
 });
 
 export const container = style({
-  display: 'flex',
+  display: 'none',
   flexDirection: 'column',
   position: 'fixed',
   top: '50%',
@@ -28,6 +18,16 @@ export const container = style({
   borderRadius: '0.8rem',
   boxShadow: '0 0.4rem 0.8rem rgba(0, 0, 0, 0.25)',
   transform: 'translate(-50%, -50%)',
+  '::backdrop': {
+    background: 'rgba(14, 31, 24, 0.05)',
+    backdropFilter: 'blur(0.2rem)',
+  },
+
+  selectors: {
+    [`&[open]`]: {
+      display: 'flex',
+    },
+  },
 });
 
 export const inputArea = style({

--- a/app/frontend/src/components/commons/Modal/index.tsx
+++ b/app/frontend/src/components/commons/Modal/index.tsx
@@ -1,7 +1,7 @@
 import { sansBold24, sansRegular16 } from '@/styles/font.css';
 
+import { Footer } from './Footer';
 import * as styles from './index.css';
-import { Button } from '../Button';
 
 type ModalProps = {
   title: string;
@@ -28,23 +28,12 @@ export function Modal({
           <div className={sansBold24}>{title}</div>
           {content && <div className={sansRegular16}>{content}</div>}
         </div>
-        <div className={styles.buttonArea}>
-          <Button
-            type="button"
-            theme="primary"
-            shape="fill"
-            size="large"
-            fullWidth
-            onClick={buttonType === 'double' ? onClickConfirm : undefined}
-          >
-            {confirmButtonText}
-          </Button>
-          {buttonType === 'double' && (
-            <Button type="button" theme="primary" shape="line" size="large" fullWidth>
-              {cancelButtonText}
-            </Button>
-          )}
-        </div>
+        <Footer
+          buttonType={buttonType}
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          onClickConfirm={onClickConfirm}
+        />
       </dialog>
     </>
   );

--- a/app/frontend/src/components/commons/Modal/index.tsx
+++ b/app/frontend/src/components/commons/Modal/index.tsx
@@ -21,28 +21,31 @@ export function Modal({
   onClickConfirm,
 }: ModalProps) {
   return (
-    <dialog className={styles.container}>
-      <div className={styles.textArea}>
-        <div className={sansBold24}>{title}</div>
-        {content && <div className={sansRegular16}>{content}</div>}
-      </div>
-      <div className={styles.buttonArea}>
-        <Button
-          type="button"
-          theme="primary"
-          shape="fill"
-          size="large"
-          fullWidth
-          onClick={buttonType === 'double' ? onClickConfirm : undefined}
-        >
-          {confirmButtonText}
-        </Button>
-        {buttonType === 'double' && (
-          <Button type="button" theme="primary" shape="line" size="large" fullWidth>
-            {cancelButtonText}
+    <>
+      <div className={styles.background} />
+      <dialog className={styles.container}>
+        <div className={styles.textArea}>
+          <div className={sansBold24}>{title}</div>
+          {content && <div className={sansRegular16}>{content}</div>}
+        </div>
+        <div className={styles.buttonArea}>
+          <Button
+            type="button"
+            theme="primary"
+            shape="fill"
+            size="large"
+            fullWidth
+            onClick={buttonType === 'double' ? onClickConfirm : undefined}
+          >
+            {confirmButtonText}
           </Button>
-        )}
-      </div>
-    </dialog>
+          {buttonType === 'double' && (
+            <Button type="button" theme="primary" shape="line" size="large" fullWidth>
+              {cancelButtonText}
+            </Button>
+          )}
+        </div>
+      </dialog>
+    </>
   );
 }

--- a/app/frontend/src/components/commons/Modal/index.tsx
+++ b/app/frontend/src/components/commons/Modal/index.tsx
@@ -1,5 +1,7 @@
-/* eslint-disable react/require-default-props */
+import { sansBold24, sansRegular16 } from '@/styles/font.css';
+
 import * as styles from './index.css';
+import { Button } from '../Button';
 
 type ModalProps = {
   title: string;
@@ -21,17 +23,24 @@ export function Modal({
   return (
     <dialog className={styles.container}>
       <div className={styles.textArea}>
-        <div className={styles.title}>{title}</div>
-        {content && <div className={styles.content}>{content}</div>}
+        <div className={sansBold24}>{title}</div>
+        {content && <div className={sansRegular16}>{content}</div>}
       </div>
       <div className={styles.buttonArea}>
-        <button type="button" onClick={buttonType === 'double' ? onClickConfirm : undefined} className={styles.button}>
+        <Button
+          type="button"
+          theme="primary"
+          shape="fill"
+          size="large"
+          fullWidth
+          onClick={buttonType === 'double' ? onClickConfirm : undefined}
+        >
           {confirmButtonText}
-        </button>
+        </Button>
         {buttonType === 'double' && (
-          <button type="button" className={styles.button}>
+          <Button type="button" theme="primary" shape="line" size="large" fullWidth>
             {cancelButtonText}
-          </button>
+          </Button>
         )}
       </div>
     </dialog>

--- a/app/frontend/src/components/commons/Modal/index.tsx
+++ b/app/frontend/src/components/commons/Modal/index.tsx
@@ -4,6 +4,7 @@ import { Footer } from './Footer';
 import * as styles from './index.css';
 
 type ModalProps = {
+  dialogRef: React.RefObject<HTMLDialogElement>;
   title: string;
   content?: string;
   buttonType: 'single' | 'double';
@@ -13,6 +14,7 @@ type ModalProps = {
 };
 
 export function Modal({
+  dialogRef,
   title,
   content = '',
   buttonType,
@@ -20,21 +22,24 @@ export function Modal({
   cancelButtonText = '취소',
   onClickConfirm,
 }: ModalProps) {
+  const closeModal = () => {
+    if (!dialogRef.current) return;
+    dialogRef.current.close();
+  };
+
   return (
-    <>
-      <div className={styles.background} />
-      <dialog className={styles.container}>
-        <div className={styles.textArea}>
-          <div className={sansBold24}>{title}</div>
-          {content && <div className={sansRegular16}>{content}</div>}
-        </div>
-        <Footer
-          buttonType={buttonType}
-          confirmButtonText={confirmButtonText}
-          cancelButtonText={cancelButtonText}
-          onClickConfirm={onClickConfirm}
-        />
-      </dialog>
-    </>
+    <dialog className={styles.container} ref={dialogRef}>
+      <div className={styles.textArea}>
+        <div className={sansBold24}>{title}</div>
+        {content && <div className={sansRegular16}>{content}</div>}
+      </div>
+      <Footer
+        buttonType={buttonType}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
+        closeModal={closeModal}
+        onClickConfirm={onClickConfirm}
+      />
+    </dialog>
   );
 }

--- a/app/frontend/src/components/commons/Modal/index.tsx
+++ b/app/frontend/src/components/commons/Modal/index.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/require-default-props */
+import * as styles from './index.css';
+
+type ModalProps = {
+  title: string;
+  content?: string;
+  buttonType: 'single' | 'double';
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onClickConfirm: () => void;
+};
+
+export function Modal({
+  title,
+  content = '',
+  buttonType,
+  confirmButtonText = '확인',
+  cancelButtonText = '취소',
+  onClickConfirm,
+}: ModalProps) {
+  return (
+    <dialog className={styles.container}>
+      <div className={styles.textArea}>
+        <div className={styles.title}>{title}</div>
+        {content && <div className={styles.content}>{content}</div>}
+      </div>
+      <div className={styles.buttonArea}>
+        <button type="button" onClick={buttonType === 'double' ? onClickConfirm : undefined} className={styles.button}>
+          {confirmButtonText}
+        </button>
+        {buttonType === 'double' && (
+          <button type="button" className={styles.button}>
+            {cancelButtonText}
+          </button>
+        )}
+      </div>
+    </dialog>
+  );
+}

--- a/app/frontend/src/styles/reset.css.ts
+++ b/app/frontend/src/styles/reset.css.ts
@@ -1,7 +1,11 @@
 import { globalStyle } from '@vanilla-extract/css';
 
+globalStyle('*', {
+  boxSizing: 'border-box',
+});
+
 globalStyle(
-  'html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, input',
+  'html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, dialog, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, input',
   {
     margin: 0,
     padding: 0,


### PR DESCRIPTION
## 설명
close #87
- 재사용 가능한 모달 컴포넌트를 만듭니다.

## 완료한 기능 명세
- [x] Modal 컴포넌트 코드 작성
- [x] Modal 스타일링 코드 작성
- [x] InputModal 컴포넌트 코드 작성
- [x] InputModal 스타일링 코드 작성

### 스크린샷
![0](https://github.com/boostcampwm2023/web17_morak/assets/50646827/b14bc980-bab8-4f04-adc9-5ab3a3900836)

https://github.com/boostcampwm2023/web17_morak/assets/50646827/1953e841-b971-4f7b-a5b3-add6b52e5618

### 사용법
- Modal 컴포넌트는 내부에서 `React.ref` 객체를 사용합니다.
```tsx
function App() {
  const ref = useRef<HTMLDialogElement>(null); // ref 객체를 Dialog 타입으로 선언

  const openModal = () => ref.current?.showModal(); // 모달을 열 때에는 .showModal() 메소드 사용

  return (
    <>
      <Modal dialogRef={ref} buttonType="double" title="제목" onClickConfirm={...} /> // ref를 props로 전달
    </>
  );
}
```

## 리뷰 요청 사항
- 아직 모달의 상세한 동작 방식은 생각하지 않고 UI를 위주로 구현한 상태입니다. 이후 구현 과정에 따라 일부 정의가 달라질 수 있습니다.