### PR TITLE
[Feat] Prisma Modelling 변경

### DIFF
--- a/app/backend/prisma/migrations/20231118060930_init/migration.sql
+++ b/app/backend/prisma/migrations/20231118060930_init/migration.sql
@@ -1,0 +1,81 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Member` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE `Member`;
+
+-- CreateTable
+CREATE TABLE `User` (
+    `user_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `provider_id` VARCHAR(191) NOT NULL,
+    `email` VARCHAR(191) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `social_type` VARCHAR(191) NOT NULL,
+    `nickname` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `User_provider_id_key`(`provider_id`),
+    PRIMARY KEY (`user_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Mogako` (
+    `post_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `group_id` INTEGER NOT NULL,
+    `title` VARCHAR(191) NULL,
+    `contents` VARCHAR(191) NULL,
+    `date` DATETIME(3) NOT NULL,
+    `max_human_count` INTEGER NOT NULL DEFAULT 0,
+    `human_count` INTEGER NOT NULL DEFAULT 0,
+    `address` VARCHAR(191) NULL,
+    `status` VARCHAR(191) NULL,
+    `view_count` INTEGER NOT NULL DEFAULT 0,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `Mogako_post_id_key`(`post_id`),
+    INDEX `group_id`(`group_id`),
+    PRIMARY KEY (`post_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `GroupToUser` (
+    `group_id` INTEGER NOT NULL,
+    `user_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`group_id`, `user_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Group` (
+    `group_id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`group_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Participant` (
+    `post_id` INTEGER NOT NULL,
+    `user_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`post_id`, `user_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Mogako` ADD CONSTRAINT `Mogako_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GroupToUser` ADD CONSTRAINT `GroupToUser_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `Group`(`group_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GroupToUser` ADD CONSTRAINT `GroupToUser_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Participant` ADD CONSTRAINT `Participant_post_id_fkey` FOREIGN KEY (`post_id`) REFERENCES `Mogako`(`post_id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Participant` ADD CONSTRAINT `Participant_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`user_id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -10,11 +10,62 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model  Member {
-  id    Int      @id @default(autoincrement())
+model User {
+  user_id     Int      @id @default(autoincrement())
   provider_id String @unique
-  email String @unique
-  nickname  String
+  email       String?
+  created_at  DateTime @default(now())
   social_type String
-  created_at DateTime @default(now())
+  nickname    String
+
+  mogakos     Mogako[]
+  groupToUsers GroupToUser[]
+  participants Participant[]
+}
+
+model Mogako {
+  post_id     Int      @id @default(autoincrement()) @unique
+  user_id     Int
+  group_id    Int
+  title       String?
+  contents    String?
+  date        DateTime
+  max_human_count Int     @default(0)
+  human_count Int     @default(0)
+  address     String?
+  status      String?
+  view_count  Int     @default(0)
+  created_at  DateTime @default(now())
+  updated_at  DateTime @default(now())
+
+  author      User     @relation(fields: [user_id], references: [user_id])
+  participants Participant[]
+
+  @@index([group_id], name: "group_id")
+}
+
+model GroupToUser {
+  group_id    Int
+  user_id     Int
+
+  group       Group    @relation(fields: [group_id], references: [group_id])
+  user        User     @relation(fields: [user_id], references: [user_id])
+
+  @@id([group_id, user_id])
+}
+
+model Group {
+  group_id    Int          @id @default(autoincrement())
+  title       String
+  mogakos     GroupToUser[]
+}
+
+model Participant {
+  post_id     Int
+  user_id     Int
+
+  post        Mogako   @relation(fields: [post_id], references: [post_id])
+  user        User     @relation(fields: [user_id], references: [user_id])
+
+  @@id([post_id, user_id])
 }

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../libs/utils/prisma.service';
 import { CreateUserDto } from './dto/user.dto';
-import { Member } from '@prisma/client';
+import { User } from '@prisma/client';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 
@@ -12,16 +12,16 @@ export class AuthRepository {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
-  async saveUser(userDto: CreateUserDto): Promise<Member> {
-    return this.prisma.member.create({
+  async saveUser(userDto: CreateUserDto): Promise<User> {
+    return this.prisma.user.create({
       data: {
         ...userDto,
       },
     });
   }
 
-  async findUserByIdentifier(provider_id: string): Promise<Member | null> {
-    return this.prisma.member.findUnique({
+  async findUserByIdentifier(provider_id: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
       where: {
         provider_id,
       },


### PR DESCRIPTION
## 설명
- close #90 
 
채팅, 댓글 기능을 제외하고 ERD에 맞춰서 모델링을 하였습니다.
댓글과 채팅에 대한 db는 아직 세팅하지 않았습니다.

그룹, 그룹 맵핑, 모각코, 참석자에 관한 모델링을 하였습니다.
DB Table을 변경하였기 때문에 변경 이후 아래 두 줄의 코드를 작성하여서 새로 마이그레이션 폴더를 생성한 이후 
dev를 통해서 마이그레이션 하였습니다.

``` bash
npx prisma migrate dev --name init // mirgration 파일에 저장하기
npx prisma migrate dev // 마이그레이션
```

## 완료한 기능 명세
- [x] Prisma Modelling

### 스크린샷
<img width="969" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/ace3aab3-727f-495e-a3f6-6157e6774ce5">


## 리뷰 요청 사항
처음 ERDCloud에서 sql preview를 하여서 해당 코드를 gpt에게 프리즈마 모델링 코드로 변경해달라고 했는데
계속 빨간 밑줄 오류가 나서 직접 ERD를 보고 코드를 수정하였습니다.

자세히 한번 확인 부탁드립니다.

