### PR TITLE
[Feat] Jwt 토큰 유저정보 추가

### DIFF
--- a/app/backend/prisma/migrations/20231119084220_init/migration.sql
+++ b/app/backend/prisma/migrations/20231119084220_init/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `email` on the `Member` table. All the data in the column will be lost.
+  - You are about to drop the column `nickname` on the `Member` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX `Member_email_key` ON `Member`;
+
+-- AlterTable
+ALTER TABLE `Member` DROP COLUMN `email`,
+    DROP COLUMN `nickname`;

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -13,8 +13,6 @@ datasource db {
 model  Member {
   id    Int      @id @default(autoincrement())
   provider_id String @unique
-  email String @unique
-  nickname  String
   social_type String
   created_at DateTime @default(now())
 }

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -44,16 +44,14 @@ export class AuthController {
   async googleLoginCallback(@Req() req, @Res() res): Promise<void> {
     try {
       const { user } = req;
-      const { providerId, socialType, name, email } = user;
-      const provider_id = providerId;
-      const social_type = socialType;
-      const nickname = name;
+      const { providerId, socialType, name, email, profilePicture } = user;
 
       const tokens = await this.authService.handleLogin({
-        provider_id,
+        provider_id: providerId,
         email,
-        nickname,
-        social_type,
+        nickname: name,
+        social_type: socialType,
+        profilePicture,
       });
 
       res.cookie('access_token', tokens.access_token, { httpOnly: true, maxAge: process.env.MAX_AGE_ACCESS_TOKEN });
@@ -122,12 +120,12 @@ export class AuthController {
   })
   @ApiResponse({ status: 200, description: 'Successful operation' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getProviderId(@Req() req: Request, @Res() res: Response): Promise<void> {
+  async getUserData(@Req() req: Request, @Res() res: Response): Promise<void> {
     try {
       const encryptedToken = req.cookies.access_token;
-      const userData = await this.authService.getProviderId(encryptedToken);
+      const userData = await this.authService.getUserData(encryptedToken);
 
-      res.json({ provider_id: userData });
+      res.json(userData);
     } catch (error) {
       throw new UnauthorizedException('Failed to get user profile');
     }

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../libs/utils/prisma.service';
 import { CreateUserDto } from './dto/user.dto';
-import { Member } from '@prisma/client';
+import { User } from '@prisma/client';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 
@@ -12,16 +12,19 @@ export class AuthRepository {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
-  async saveUser(userDto: CreateUserDto): Promise<Member> {
-    return this.prisma.member.create({
+  async saveUser(userDto: CreateUserDto): Promise<User> {
+    return this.prisma.user.create({
       data: {
-        ...userDto,
+        provider_id: userDto.provider_id,
+        email: userDto.email,
+        social_type: userDto.social_type,
+        nickname: userDto.nickname,
       },
     });
   }
 
-  async findUserByIdentifier(provider_id: string): Promise<Member | null> {
-    return this.prisma.member.findUnique({
+  async findUserByIdentifier(provider_id: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
       where: {
         provider_id,
       },

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../libs/utils/prisma.service';
 import { CreateUserDto } from './dto/user.dto';
-import { User } from '@prisma/client';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { Member } from '@prisma/client';
 
 @Injectable()
 export class AuthRepository {
@@ -12,19 +12,17 @@ export class AuthRepository {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
-  async saveUser(userDto: CreateUserDto): Promise<User> {
-    return this.prisma.user.create({
+  async saveUser(userDto: CreateUserDto): Promise<Member> {
+    return this.prisma.member.create({
       data: {
         provider_id: userDto.provider_id,
-        email: userDto.email,
         social_type: userDto.social_type,
-        nickname: userDto.nickname,
       },
     });
   }
 
-  async findUserByIdentifier(provider_id: string): Promise<User | null> {
-    return this.prisma.user.findUnique({
+  async findUserByIdentifier(provider_id: string): Promise<Member | null> {
+    return this.prisma.member.findUnique({
       where: {
         provider_id,
       },

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthRepository } from './auth.repository';
 import { CreateUserDto } from './dto/user.dto';
 import { JwtService } from '@nestjs/jwt';
-import { Payload, Tokens } from './types';
+import { Payload, Tokens, UserData } from './types';
 
 @Injectable()
 export class AuthService {
@@ -40,6 +40,9 @@ export class AuthService {
     const token = this.generateJwt({
       providerId: userDto.provider_id,
       socialType: userDto.social_type,
+      email: userDto.email,
+      profilePicture: userDto.profilePicture,
+      nickname: userDto.nickname,
     });
 
     await this.authRepository.addRefreshToken(userDto.provider_id, token.refresh_token);
@@ -67,10 +70,10 @@ export class AuthService {
     await this.authRepository.removeRefreshToken(provider_id);
   }
 
-  async getProviderId(encryptedToken: string): Promise<string> {
+  async getUserData(encryptedToken: string): Promise<UserData> {
     const decodedAccessToken = this.jwtService.verify(encryptedToken, { secret: process.env.JWT_ACCESS_SECRET });
-    const { providerId } = decodedAccessToken;
+    const { providerId, email, nickname, profilePicture } = decodedAccessToken;
 
-    return providerId;
+    return { providerId, email, nickname, profilePicture };
   }
 }

--- a/app/backend/src/auth/dto/user.dto.ts
+++ b/app/backend/src/auth/dto/user.dto.ts
@@ -19,6 +19,10 @@ export class CreateUserDto {
   @ApiProperty()
   @IsString()
   social_type: string;
+
+  @ApiProperty()
+  @IsString()
+  profilePicture: string;
 }
 
 export class LogoutDto {

--- a/app/backend/src/auth/types/index.ts
+++ b/app/backend/src/auth/types/index.ts
@@ -1,2 +1,3 @@
 export * from './tokens.interface';
 export * from './payload.interface';
+export * from './user.interface';

--- a/app/backend/src/auth/types/user.interface.ts
+++ b/app/backend/src/auth/types/user.interface.ts
@@ -1,0 +1,6 @@
+export interface UserData {
+  providerId: string;
+  email: string;
+  nickname: string;
+  profilePicture: string;
+}


### PR DESCRIPTION
## 설명
- close #93 
Jwt 토큰에 유저 정보를 추가합니다.
클라이언트에 사용자 정보를 전달하기 위한 Get API에 기능을 추가하였습니다.
원래 provider_id만 넘겨주는 형식이었지만 기획과 클라이언트에 필요한 정보가 더 필요하여 추가하였습니다.

## 완료한 기능 명세
- [x] Jwt 토큰 유저정보 추가

### 스크린샷
<img width="1193" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/c73bd2c8-6852-443b-9700-1dff1949961d">

## 리뷰 요청 사항
x
