### PR TITLE
[Feat] Textarea 퍼블리싱

### DIFF
--- a/app/frontend/src/components/commons/Input/Textarea.css.ts
+++ b/app/frontend/src/components/commons/Input/Textarea.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+import { input } from './index.css';
+
+export * from './index.css';
+export const textarea = style([
+  input,
+  {
+    resize: 'none',
+  },
+]);

--- a/app/frontend/src/components/commons/Input/Textarea.tsx
+++ b/app/frontend/src/components/commons/Input/Textarea.tsx
@@ -1,0 +1,39 @@
+import * as styles from './Textarea.css';
+
+type TextareaProps = {
+  label?: string;
+  maxLength: number;
+  placeholder?: string;
+  errorMessage?: string;
+  disabled?: boolean;
+  required?: boolean;
+};
+
+export function Textarea({
+  label,
+  placeholder = '',
+  errorMessage = '',
+  disabled = false,
+  maxLength,
+  required = false,
+}: TextareaProps) {
+  return (
+    <div className={`${styles.container} ${errorMessage && styles.error} ${disabled && styles.disabled}`}>
+      <div className={styles.titleWrapper}>
+        <span className={`${styles.label} ${!label && styles.hide}`}>
+          {label}
+          {required && <span className={styles.required}>*</span>}
+        </span>
+        <span className={styles.count}>0/{maxLength}</span>
+      </div>
+      <textarea
+        className={styles.textarea}
+        placeholder={placeholder}
+        disabled={disabled}
+        maxLength={maxLength}
+        required={required}
+      />
+      {!disabled && errorMessage && <p className={styles.errorMessage}>{errorMessage}</p>}
+    </div>
+  );
+}

--- a/app/frontend/src/components/commons/Input/index.css.ts
+++ b/app/frontend/src/components/commons/Input/index.css.ts
@@ -32,6 +32,8 @@ export const errorMessage = style([
   },
 ]);
 
+export const hide = style({});
+
 export const input = style([
   fontStyle.sansRegular12,
   {
@@ -59,7 +61,6 @@ export const input = style([
     },
   },
 ]);
-
 export const label = style([
   fontStyle.sansRegular12,
   {
@@ -67,6 +68,9 @@ export const label = style([
     selectors: {
       [`${disabled} &`]: {
         color: vars.color.grayscale200,
+      },
+      [`${hide} &`]: {
+        visibility: 'hidden',
       },
     },
   },
@@ -82,5 +86,6 @@ export const titleWrapper = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   width: '100%',
+  minHeight: '1.2rem',
   marginBottom: '0.4rem',
 });

--- a/app/frontend/src/components/commons/Input/index.tsx
+++ b/app/frontend/src/components/commons/Input/index.tsx
@@ -24,7 +24,7 @@ export function Input({
   return (
     <div className={`${styles.container} ${errorMessage && styles.error} ${disabled && styles.disabled}`}>
       <div className={styles.titleWrapper}>
-        <span className={styles.label}>
+        <span className={`${styles.label} ${!label && styles.hide}`}>
           {label}
           {required && <span className={styles.required}>*</span>}
         </span>

--- a/app/frontend/src/components/index.ts
+++ b/app/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './commons/Button';
 export * from './commons/Header';
 export * from './commons/Input';
+export * from './commons/Input/Textarea';
 export * from './commons/Popover';


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- Input 디자인과 같은 Textarea 컴포넌트 생성
- index.css.ts 파일을 Textarea.css.ts에서 그대로 Export 했습니다. 추가적으로 스타일이 필요한 부분은 상속하여 사용할 수 있도록 했습니다.
- Input/Textarea의 제목(라벨) 필드를 옵셔널로 변경하고, 영역은 그대로 차지하도록 두었습니다. focus 되었을 때 글자 수를 표시하는 부분이 생겨 height가 변경되기 때문입니다.
- closed #49 

## 완료한 기능 명세
- [x] Textarea 퍼블리싱 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="346" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/f958fbd5-0797-40b8-978d-244426864f78">

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

