### PR TITLE
[Feat] Google OAuth 수정 사항

### DIFF
--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -74,8 +74,11 @@ export class AuthController {
         profilePicture,
       });
 
-      res.cookie('access_token', tokens.access_token, { httpOnly: true, maxAge: getSecret('MAX_AGE_ACCESS_TOKEN') });
-      res.cookie('refresh_token', tokens.refresh_token, { httpOnly: true, maxAge: getSecret('MAX_AGE_REFRESH_TOKEN') });
+      res.cookie('access_token', tokens.access_token, { httpOnly: false, maxAge: getSecret('MAX_AGE_ACCESS_TOKEN') });
+      res.cookie('refresh_token', tokens.refresh_token, {
+        httpOnly: false,
+        maxAge: getSecret('MAX_AGE_REFRESH_TOKEN'),
+      });
 
       res.redirect(getSecret(`AUTH_REDIRECT_URL`));
     } catch (error) {
@@ -108,12 +111,15 @@ export class AuthController {
       const newAccessToken = await this.authService.refresh(cookieRefreshToken);
 
       res.setHeader('Authorization', 'Bearer ' + newAccessToken);
-      res.cookie('access_token', newAccessToken, { httpOnly: true, maxAge: Number(getSecret('MAX_AGE_ACCESS_TOKEN')) });
+      res.cookie('access_token', newAccessToken, {
+        httpOnly: false,
+        maxAge: Number(getSecret('MAX_AGE_ACCESS_TOKEN')),
+      });
 
       res.json({ newAccessToken });
     } catch (err) {
-      res.clearCookie('access_token', { httpOnly: true });
-      res.clearCookie('refresh_token', { httpOnly: true });
+      res.clearCookie('access_token', { httpOnly: false });
+      res.clearCookie('refresh_token', { httpOnly: false });
       throw new UnauthorizedException('Failed to refresh token');
     }
   }
@@ -136,8 +142,8 @@ export class AuthController {
       const { providerId } = body;
       await this.authService.logout(providerId);
 
-      res.clearCookie('access_token', { httpOnly: true });
-      res.clearCookie('refresh_token', { httpOnly: true });
+      res.clearCookie('access_token', { httpOnly: false });
+      res.clearCookie('refresh_token', { httpOnly: false });
     } catch (error) {
       console.error('Logout error:', error);
       throw new UnauthorizedException('Failed to logout');

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -58,6 +58,12 @@ export class AuthController {
           type: 'string',
         },
       },
+      Authorization: {
+        description: 'Bearer token for authorization',
+        schema: {
+          type: 'string',
+        },
+      },
     },
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -73,6 +79,8 @@ export class AuthController {
         social_type: socialType,
         profilePicture,
       });
+
+      res.setHeader('Authorization', 'Bearer ' + [tokens.access_token, tokens.refresh_token]);
 
       res.cookie('access_token', tokens.access_token, { httpOnly: false, maxAge: getSecret('MAX_AGE_ACCESS_TOKEN') });
       res.cookie('refresh_token', tokens.refresh_token, {

--- a/app/backend/src/auth/interface/payload.interface.ts
+++ b/app/backend/src/auth/interface/payload.interface.ts
@@ -2,5 +2,5 @@ import { JwtPayload } from 'jsonwebtoken';
 
 export interface Payload extends JwtPayload {
   providerId: string;
-  refreshToken?: string;
+  socialType: string;
 }


### PR DESCRIPTION
## 설명
공수가 너무 많이 들어갈 것으로 예상되어 httponly를 false로 변경하여 클라이언트에서 쿠키에 접근할 수 있도록 합니다.
추후에 여유가 생긴다면 보안에 신경쓰면서 보수를 할 예정입니다.

## 완료한 기능 명세
- [x]  Access, Refresh Token을 헤더, 쿠키에 담아 클라이언트에 심어주고 전달합니다. 
httponly=false

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

