### PR TITLE
[Fix] Sidebar 컴포넌트 위치 관련 버그 수정

### DIFF
--- a/app/frontend/src/components/commons/Sidebar/index.css.ts
+++ b/app/frontend/src/components/commons/Sidebar/index.css.ts
@@ -41,10 +41,10 @@ export const panel = style({
 export const wrapper = style({
   display: 'flex',
   alignItems: 'center',
-  position: 'absolute',
-  top: 0,
+  position: 'fixed',
+  top: '8.6rem',
   left: 0,
   zIndex: 100,
-  height: '100%',
+  height: 'calc(100% - 8.6rem)',
   transition: 'transform 0.5s',
 });

--- a/app/frontend/src/styles/reset.css.ts
+++ b/app/frontend/src/styles/reset.css.ts
@@ -25,16 +25,16 @@ globalStyle(
 
 globalStyle('html', {
   fontSize: '62.5%',
-  height: '100%',
+  minHeight: '100vh',
 });
 
 globalStyle('body', {
   lineHeight: 1,
-  height: '100%',
+  minHeight: '100vh',
 });
 
 globalStyle('#root', {
-  height: '100%',
+  minHeight: '100vh',
 });
 
 globalStyle('ol, ul', {


### PR DESCRIPTION
## 설명
- Sidebar 컴포넌트의 위치가 고정되지 않는 버그를 수정했습니다.

## 완료한 기능 명세
- Sidebar 컴포넌트에 `position: 'fixed'` 속성 할당, 이후 위치 조정
- reset.css.ts에서 html, body, #root 요소에 `minHeight: '100vh'` 속성 추가

### 동작 화면
https://github.com/boostcampwm2023/web17_morak/assets/50646827/875a0d98-2470-4974-9651-309f0081567b

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기
- 없음
