### PR TITLE
[Design] 모각코 리스트 뷰 퍼블리싱

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query": "^5.8.1",
     "@tanstack/react-query-devtools": "^5.8.1",
     "@vanilla-extract/css": "^1.14.0",
+    "@vanilla-extract/css-utils": "^0.1.3",
     "@vanilla-extract/recipes": "^0.5.1",
     "axios": "^1.6.1",
     "dayjs": "^1.11.10",

--- a/app/frontend/src/components/Mogaco/MogacoList.css.ts
+++ b/app/frontend/src/components/Mogaco/MogacoList.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2rem',
+});

--- a/app/frontend/src/components/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/components/Mogaco/MogacoList.tsx
@@ -1,0 +1,57 @@
+import * as styles from './MogacoList.css';
+import { MogacoItem } from '../commons/MogacoItem';
+
+export function MogacoList() {
+  const MOGACO_ITEM = [
+    {
+      id: 1,
+      title: '사당역 모각코',
+      group: '부스트캠프 웹 모바일 8기',
+      detail:
+        '사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 사당역에서 부스트캠프 모락 팀이 모입니다 ',
+      people: 2,
+      maxPeople: 5,
+      location: '서울 관악구 어디길 22 모락 카페',
+      date: '2022-02-02',
+    },
+    {
+      id: 1,
+      title: '사당역 모각코',
+      group: '부스트캠프 웹 모바일 8기',
+      detail: '사당역에서 부스트캠프 모락 팀이 모입니다',
+      people: 2,
+      maxPeople: 5,
+      location: '서울 관악구 어디길 22 모락 카페',
+      date: '2022-02-02',
+    },
+    {
+      id: 1,
+      title: '사당역 모각코',
+      group: '부스트캠프 웹 모바일 8기',
+      detail: '사당역에서 부스트캠프 모락 팀이 모입니다',
+      people: 2,
+      maxPeople: 5,
+      location: '서울 관악구 어디길 22 모락 카페',
+      date: '2022-02-02',
+    },
+  ];
+  return (
+    <div className={styles.container}>
+      {MOGACO_ITEM.map(
+        ({ id, title, group, detail, people, maxPeople, location, date }) => (
+          <MogacoItem
+            key={id}
+            id={id}
+            title={title}
+            group={group}
+            detail={detail}
+            people={people}
+            maxPeople={maxPeople}
+            location={location}
+            date={date}
+          />
+        ),
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
+++ b/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles';
+import { sansBold16, sansRegular16 } from '@/styles/font.css';
+
+export const container = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const filter = style([
+  sansRegular16,
+  {
+    display: 'flex',
+    gap: '0.8rem',
+    color: vars.color.grayscale200,
+  },
+]);
+
+export const selected = style([
+  sansBold16,
+  {
+    selectors: {
+      [`${filter} &`]: {
+        color: vars.color.grayscale400,
+      },
+    },
+  },
+]);

--- a/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
+++ b/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
@@ -7,6 +7,7 @@ export const container = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  padding: '1rem',
 });
 
 export const filter = style([

--- a/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
+++ b/app/frontend/src/components/Mogaco/MogacoListHeader.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
 import { sansBold16, sansRegular16 } from '@/styles/font.css';
@@ -28,3 +28,11 @@ export const selected = style([
     },
   },
 ]);
+
+globalStyle(`${filter} span`, {
+  cursor: 'pointer',
+});
+
+globalStyle(`${filter} span:not(${selected})`, {
+  cursor: 'not-allowed',
+});

--- a/app/frontend/src/components/Mogaco/MogacoListHeader.tsx
+++ b/app/frontend/src/components/Mogaco/MogacoListHeader.tsx
@@ -1,0 +1,17 @@
+import * as styles from './MogacoListHeader.css';
+import { Button } from '../commons/Button';
+
+export function MogacoListHeader() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.filter}>
+        <span className={styles.selected}>전체</span>
+        <span>모집 중</span>
+        <span>모집 마감</span>
+      </div>
+      <Button size="medium" type="button" theme="primary" shape="fill">
+        글쓰기
+      </Button>
+    </div>
+  );
+}

--- a/app/frontend/src/components/Mogaco/index.css.ts
+++ b/app/frontend/src/components/Mogaco/index.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  maxWidth: '80rem',
+  margin: '0 auto',
+});

--- a/app/frontend/src/components/Mogaco/index.tsx
+++ b/app/frontend/src/components/Mogaco/index.tsx
@@ -1,10 +1,12 @@
 import * as styles from './index.css';
+import { MogacoList } from './MogacoList';
 import { MogacoListHeader } from './MogacoListHeader';
 
 export function MogacoPage() {
   return (
     <div className={styles.container}>
       <MogacoListHeader />
+      <MogacoList />
     </div>
   );
 }

--- a/app/frontend/src/components/Mogaco/index.tsx
+++ b/app/frontend/src/components/Mogaco/index.tsx
@@ -1,0 +1,5 @@
+import * as styles from './index.css';
+
+export function MogacoPage() {
+  return <div className={styles.container} />;
+}

--- a/app/frontend/src/components/Mogaco/index.tsx
+++ b/app/frontend/src/components/Mogaco/index.tsx
@@ -1,5 +1,10 @@
 import * as styles from './index.css';
+import { MogacoListHeader } from './MogacoListHeader';
 
 export function MogacoPage() {
-  return <div className={styles.container} />;
+  return (
+    <div className={styles.container}>
+      <MogacoListHeader />
+    </div>
+  );
 }

--- a/app/frontend/src/components/commons/MogacoItem/index.css.ts
+++ b/app/frontend/src/components/commons/MogacoItem/index.css.ts
@@ -7,8 +7,7 @@ export const container = style([
   {
     display: 'flex',
     padding: '2rem',
-    width: '73.5rem',
-    height: '19.6rem',
+    width: '100%',
     flexDirection: 'column',
     alignItems: 'flex-start',
     gap: '1.2rem',
@@ -31,12 +30,13 @@ export const content = style([
     flexDirection: 'column',
     alignItems: 'flex-start',
     gap: '0.8rem',
+    width: '100%',
     color: vars.color.grayscaleBlack,
   },
 ]);
 
 export const detail = style({
-  width: '69.5rem',
+  width: '100%',
   height: '3.5rem',
   lineHeight: '1.8rem',
   display: '-webkit-box',
@@ -84,7 +84,6 @@ export const infoText = style({
 export const title = style([
   fontStyle.sansBold24,
   {
-    width: '42.3rem',
     color: vars.color.grayscaleBlack,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
@@ -96,4 +95,5 @@ export const titleArea = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.4rem',
+  width: '100%',
 });

--- a/app/frontend/src/components/commons/MogacoItem/index.css.ts
+++ b/app/frontend/src/components/commons/MogacoItem/index.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 
 import { vars, fontStyle } from '@/styles';
 
@@ -63,17 +64,19 @@ export const info = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
+  width: '100%',
   gap: '0.4rem',
 });
 
 export const infoContent = style({
   display: 'flex',
+  width: '100%',
   alignItems: 'center',
   gap: '0.4rem',
 });
 
 export const infoText = style({
-  width: '67.5rem',
+  width: calc.subtract('100%'),
   alignItems: 'center',
   gap: '0.4rem',
   overflow: 'hidden',

--- a/app/frontend/src/components/commons/MogacoItem/index.css.ts
+++ b/app/frontend/src/components/commons/MogacoItem/index.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { calc } from '@vanilla-extract/css-utils';
 
 import { vars, fontStyle } from '@/styles';
 
@@ -76,7 +75,7 @@ export const infoContent = style({
 });
 
 export const infoText = style({
-  width: calc.subtract('100%'),
+  width: '100%',
   alignItems: 'center',
   gap: '0.4rem',
   overflow: 'hidden',

--- a/app/frontend/src/components/commons/MogacoItem/index.tsx
+++ b/app/frontend/src/components/commons/MogacoItem/index.tsx
@@ -4,20 +4,9 @@ import { ReactComponent as Calendar } from '@/assets/icons/calendar.svg';
 import { ReactComponent as Map } from '@/assets/icons/map.svg';
 import { ReactComponent as People } from '@/assets/icons/people.svg';
 import { Label } from '@/components';
+import { MogacoProps } from '@/types';
 
 import * as styles from './index.css';
-
-type MogacoProps = {
-  id: number;
-  disabled?: boolean;
-  title: string;
-  group: string;
-  detail: string;
-  people: number;
-  maxPeople: number;
-  location: string;
-  date: string;
-};
 
 export function MogacoItem({
   id,

--- a/app/frontend/src/components/index.ts
+++ b/app/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Mogaco';
 export * from './commons/Button';
 export * from './commons/Chatting';
 export * from './commons/Header';

--- a/app/frontend/src/hooks/useRouter.tsx
+++ b/app/frontend/src/hooks/useRouter.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 
 import { Layout } from '@/components';
-import { Main } from '@/pages';
+import { Main, Mogaco } from '@/pages';
 
 export const useRouter = () =>
   createBrowserRouter([
@@ -12,7 +12,7 @@ export const useRouter = () =>
         { index: true, element: <Main /> },
         {
           path: 'mogaco',
-          element: <>모각코</>,
+          element: <Mogaco />,
         },
         {
           path: 'calendar',

--- a/app/frontend/src/pages/Mogaco/index.tsx
+++ b/app/frontend/src/pages/Mogaco/index.tsx
@@ -1,0 +1,5 @@
+import { MogacoPage } from '@/components';
+
+export function Mogaco() {
+  return <MogacoPage />;
+}

--- a/app/frontend/src/pages/index.ts
+++ b/app/frontend/src/pages/index.ts
@@ -1,1 +1,2 @@
+export * from './Mogaco';
 export { Main } from './Main';

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './chatting';
+export * from './mogaco';
 export * from './user';

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -1,0 +1,11 @@
+export type MogacoProps = {
+  id: number;
+  disabled?: boolean;
+  title: string;
+  group: string;
+  detail: string;
+  people: number;
+  maxPeople: number;
+  location: string;
+  date: string;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@tanstack/react-query": "^5.8.1",
         "@tanstack/react-query-devtools": "^5.8.1",
         "@vanilla-extract/css": "^1.14.0",
+        "@vanilla-extract/css-utils": "^0.1.3",
         "@vanilla-extract/recipes": "^0.5.1",
         "axios": "^1.6.1",
         "dayjs": "^1.11.10",
@@ -3138,6 +3139,11 @@
         "modern-ahocorasick": "^1.0.0",
         "outdent": "^0.8.0"
       }
+    },
+    "node_modules/@vanilla-extract/css-utils": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/css-utils/-/css-utils-0.1.3.tgz",
+      "integrity": "sha512-PZAcHROlgtCUGI2y0JntdNwvPwCNyeVnkQu6KTYKdmxBbK3w72XJUmLFYapfaFfgami4I9CTLnrJTPdtmS3gpw=="
     },
     "node_modules/@vanilla-extract/integration": {
       "version": "6.2.3",


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #111 
- 피그마 기준 리스트 뷰 내부의 컴포넌트 크기는 735px로 설정되어 있습니다. 735라는 숫자가 너무 애매하기도 하고, 맥스로 맞춰 놓은 1200px에 꽉 차게 작업할 경우에는 헤더보다 내용 영역이 길어져 미관상 별로였습니다. 800px로 맞추어 작업했습니다.
  - 피그마
  
    <img width="1271" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/753612ab-fdb7-4506-8013-74500e87cd36">

  - 1200px로 설정할 경우
   
    <img width="1251" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/8862d70e-015f-4eb7-8803-4df43c515765">

- 모각코 아이템 컴포넌트의 스타일을 수정했습니다. 
  - width가 고정값으로 되어 있어 이 부분을 수정하고, 화면이나 컨테이너의 width에 맞게 유동적으로 크기를 차지하도록 수정했습니다.
  - 이 과정에서 `@vanilla-extract/css-utils` 패키지를 설치했었는데, 현재는 calc를 사용한 코드는 없으나 추후 사용을 위해 삭제하지는 않았습니다.
- MogacoItem에서 사용된 MogacoProps를 공통 타입으로 분리했습니다. 백엔드의 변수명과 맞추기 위해 변경할 경우, 서로 이야기하면서 작업해야 할 것 같습니다.

## 완료한 기능 명세
- [x] 모각코 리스트 뷰 퍼블리싱 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

