### PR TITLE
[Design] layout에 기본 패딩 값을 추가

### DIFF
--- a/app/frontend/src/components/commons/Layout/index.css.ts
+++ b/app/frontend/src/components/commons/Layout/index.css.ts
@@ -3,5 +3,5 @@ import { style } from '@vanilla-extract/css';
 export const container = style({
   maxWidth: '120rem',
   margin: '0 auto',
-  padding: '8.5rem 1.2rem 0',
+  padding: '16.5rem 1.2rem 0',
 });

--- a/app/frontend/src/pages/Main/index.css.ts
+++ b/app/frontend/src/pages/Main/index.css.ts
@@ -5,7 +5,7 @@ import { vars, fontStyle } from '@/styles';
 export const container = style({
   position: 'relative',
   display: 'flex',
-  margin: '8.5rem auto',
+  margin: '0 auto',
   width: '104rem',
   height: '81.7rem',
   color: vars.color.grayscale400,


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- #126 
- 현재 디자인은 pc 버전에서 헤더와 본문 사이의 간격이 일정하게 설정되어 있습니다. 이를 각각의 페이지 컴포넌트에서 디자인하지 않고 공통적으로 사용할 수 있도록 layout의 스타일을 조정했습니다.


## 완료한 기능 명세
- [x] layout 패딩 값 수정
- [x] Main 패딩 값 수정  

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

before 

<img width="1552" alt="스크린샷 2023-11-21 17 44 53" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/6426c2e6-6e04-4449-a01f-dfc69ac5982f">
<img width="1132" alt="스크린샷 2023-11-21 23 19 49" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/7ca6ee17-c403-4980-83d2-e3ae36e0bd88">


after

<img width="1132" alt="스크린샷 2023-11-21 23 18 21" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/b24f1de5-1aae-4a8e-a954-d353f12a8b04">
<img width="1132" alt="스크린샷 2023-11-21 23 18 24" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/ede1fe29-714b-447f-9df4-1335b5806c62">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

