### PR TITLE
[Feat] 모각코 참가자 관련 로직 구현 및 Swagger 설정

### DIFF
--- a/app/backend/src/member/dto/member.dto.ts
+++ b/app/backend/src/member/dto/member.dto.ts
@@ -4,10 +4,10 @@ export class MemberDto {
   @ApiProperty({ description: 'Provider ID of the user', example: '123456' })
   providerId: string;
 
-  @ApiProperty({ description: 'Email address of the user', example: 'user@example.com' })
+  @ApiProperty({ description: 'Email address of the user', example: 'bcwm.morak@gmail.com' })
   email: string;
 
-  @ApiProperty({ description: 'Nickname of the user', example: 'john_doe' })
+  @ApiProperty({ description: 'Nickname of the user', example: 'morak morak' })
   nickname: string;
 
   @ApiProperty({ description: "URL of the user's profile picture", example: 'https://example.com/profile.jpg' })

--- a/app/backend/src/member/member.controller.ts
+++ b/app/backend/src/member/member.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Req, Res, UnauthorizedException } from '@nestjs/common';
 import { MemberService } from './member.service';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { MemberDto } from './dto/member.dto';
 
+@ApiTags('Member Infomation API')
 @Controller('member')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}

--- a/app/backend/src/mogaco/dto/create-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/create-mogaco.dto.ts
@@ -1,27 +1,35 @@
 import { IsDateString, IsEnum, IsInt, IsNotEmpty, IsOptional } from 'class-validator';
 import { MogacoStatus } from './mogaco-status.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateMogacoDto {
+  @ApiProperty({ description: 'Group ID', example: '1' })
   @IsNotEmpty()
   @IsInt()
   groupId: number;
 
+  @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
   @IsNotEmpty()
   title: string;
 
+  @ApiProperty({ description: 'Contents of the Mogaco', example: '사당역에서 모각코를 열려고 합니다.' })
   @IsNotEmpty()
   contents: string;
 
+  @ApiProperty({ description: 'Date of the Mogaco', example: '2023-11-25T12:00:00.000Z' })
   @IsNotEmpty()
   @IsDateString()
   date: string;
 
+  @ApiProperty({ description: 'Maximum number of participants', example: 5 })
   @IsNotEmpty()
   maxHumanCount: number;
 
+  @ApiProperty({ description: 'Address of the Mogaco', example: '서울특별시 관악구 어디길 22 모락 카페' })
   @IsNotEmpty()
   address: string;
 
+  @ApiProperty({ description: 'Status of the Mogaco', example: '모집 중' })
   @IsOptional()
   @IsEnum(MogacoStatus, { message: 'Invalid status' })
   status?: string;

--- a/app/backend/src/mogaco/dto/mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/mogaco.dto.ts
@@ -1,10 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class MogacoDto {
+  @ApiProperty({ description: 'ID of the Mogaco', example: 1 })
   id: bigint;
+
+  @ApiProperty({ description: 'Group ID', example: 1 })
   groupId: bigint;
+
+  @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
   title: string;
+
+  @ApiProperty({ description: 'Contents of the Mogaco', example: '사당역에서 모각코를 열려고 합니다.' })
   contents: string;
+
+  @ApiProperty({ description: 'Date of the Mogaco', example: '2023-11-22T12:00:00Z' })
   date: Date;
+
+  @ApiProperty({ description: 'Maximum number of participants', example: 5 })
   maxHumanCount: number;
+
+  @ApiProperty({ description: 'Address of the Mogaco', example: '서울특별시 관악구 어디길 22 모락 카페' })
   address: string;
+
+  @ApiProperty({ description: 'Status of the Mogaco', example: '모집 중' })
+  status: string;
+}
+
+export class StatusDto {
+  @ApiProperty({ description: 'Status of the Mogaco', example: '모집 마감' })
   status: string;
 }

--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MemberDto } from 'src/member/dto/member.dto';
+
+export class MogacoWithMemberDto {
+  @ApiProperty({ description: 'ID of the Mogaco', example: '3' })
+  id: string;
+
+  @ApiProperty({ description: 'Group ID', example: '1' })
+  groupId: string;
+
+  @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
+  title: string;
+
+  @ApiProperty({ description: 'Contents of the Mogaco', example: '사당역에서 모각코를 열려고 합니다.' })
+  contents: string;
+
+  @ApiProperty({ description: 'Date of the Mogaco', example: '2023-11-25T12:00:00.000Z' })
+  date: string;
+
+  @ApiProperty({ description: 'Maximum number of participants', example: 5 })
+  maxHumanCount: number;
+
+  @ApiProperty({ description: 'Address of the Mogaco', example: '서울특별시 관악구 어디길 22 모락 카페' })
+  address: string;
+
+  @ApiProperty({ description: 'Status of the Mogaco', example: '모집 마감' })
+  status: string;
+
+  @ApiProperty({ description: 'Date of Mogaco creation', example: '2023-11-22T12:16:08.913Z' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Date of Mogaco update', example: '2023-11-22T12:16:08.913Z' })
+  updatedAt: string;
+
+  @ApiProperty({ description: 'Date of Mogaco deletion', example: null })
+  deletedAt: string | null;
+
+  @ApiProperty({ description: 'Member information', type: MemberDto })
+  member: MemberDto;
+}

--- a/app/backend/src/mogaco/dto/response-participants.dto.ts
+++ b/app/backend/src/mogaco/dto/response-participants.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ParticipantResponseDto {
+  @ApiProperty({ description: 'ID of the Member', example: '1' })
+  id: string;
+
+  @ApiProperty({ description: 'Provider ID', example: '117187214221556274884' })
+  providerId: string;
+
+  @ApiProperty({ description: 'Email of the Member', example: 'bcwm.morak@gmail.com' })
+  email: string;
+
+  @ApiProperty({ description: 'Social Type', example: 'google' })
+  socialType: string;
+
+  @ApiProperty({ description: 'Date of Member creation', example: '2023-11-22T04:55:02.988Z' })
+  createdAt: string;
+}

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -80,6 +80,24 @@ export class MogacoController {
     return this.mogacoService.updateMogacoStatus(id, status);
   }
 
+  @Patch('/:id')
+  @ApiOperation({
+    summary: '모각코 수정',
+    description: '특정 모각코를 수정합니다.',
+  })
+  @ApiParam({ name: 'id', description: '수정할 모각코의 Id' })
+  @ApiBody({ type: CreateMogacoDto })
+  @ApiResponse({ status: 200, description: 'Successfully updated', type: MogacoWithMemberDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  async updateMogaco(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateMogacoDto: CreateMogacoDto,
+    @GetUser() member: Member,
+  ): Promise<Mogaco> {
+    return this.mogacoService.updateMogaco(id, updateMogacoDto, member);
+  }
+
   @Post('/:id/join')
   @ApiOperation({
     summary: '모각코 참가',

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -1,42 +1,106 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
 import { MogacoService } from './mogaco.service';
 import { Member, Mogaco } from '@prisma/client';
-import { CreateMogacoDto, MogacoDto } from './dto';
+import { CreateMogacoDto, MogacoDto, StatusDto } from './dto';
 import { MogacoStatusValidationPipe } from './pipes/mogaco-status-validation.pipe';
 import { MogacoStatus } from './dto/mogaco-status.enum';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
+import { ParticipantResponseDto } from './dto/response-participants.dto';
 
+@ApiTags('Mogaco API')
 @Controller('mogaco')
 @UseGuards(AtGuard)
 export class MogacoController {
   constructor(private readonly mogacoService: MogacoService) {}
 
   @Get('/')
+  @ApiOperation({
+    summary: '모든 모각코 조회',
+    description: '존재하는 모든 모각코를 조회합니다.\n 배열로 여러 개를 반환합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [MogacoDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllMogaco(): Promise<Mogaco[]> {
     return this.mogacoService.getAllMogaco();
   }
 
   @Get('/:id')
+  @ApiOperation({
+    summary: '특정 게시물 조회',
+    description: '특정 게시물의 Id 값으로 해당 게시물을 조회합니다.',
+  })
+  @ApiParam({ name: 'id', description: '조회할 모각코의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: MogacoDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMogacoById(@Param('id', ParseIntPipe) id: number): Promise<MogacoDto> {
     return this.mogacoService.getMogacoById(id);
   }
 
   @Post('/')
+  @ApiOperation({
+    summary: '모각코 개설',
+    description: '새로운 모각코를 개설합니다.',
+  })
+  @ApiBody({ type: CreateMogacoDto })
+  @ApiResponse({ status: 201, description: 'Successfully created', type: MogacoWithMemberDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async createMogaco(@Body() createMogacoDto: CreateMogacoDto, @GetUser() member: Member): Promise<Mogaco> {
     return this.mogacoService.createMogaco(createMogacoDto, member);
   }
 
   @Delete('/:id')
+  @ApiOperation({
+    summary: '모각코 삭제',
+    description: '특정 모각코를 삭제합니다.',
+  })
+  @ApiParam({ name: 'id', description: '삭제할 모각코의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async deleteMogaco(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.mogacoService.deleteMogaco(id, member);
   }
 
   @Patch('/:id/status')
+  @ApiOperation({
+    summary: '모각코 상태 업데이트',
+    description: '특정 모각코의 상태를 업데이트합니다.',
+  })
+  @ApiParam({ name: 'id', description: '상태를 업데이트할 모각코의 Id' })
+  @ApiBody({ type: StatusDto })
+  @ApiResponse({ status: 200, description: 'Successfully Updated', type: MogacoWithMemberDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   updateMogacoStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body('status', MogacoStatusValidationPipe) status: MogacoStatus,
   ): Promise<Mogaco> {
     return this.mogacoService.updateMogacoStatus(id, status);
+  }
+
+  @Post('/:id/join')
+  @ApiOperation({
+    summary: '모각코 참가',
+    description: '특정 모각코에 참가합니다.',
+  })
+  @ApiParam({ name: 'id', description: '참가할 모각코의 Id' })
+  @ApiResponse({ status: 201, description: 'Successfully join' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async joinMogaco(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
+    return this.mogacoService.joinMogaco(id, member);
+  }
+
+  @Get('/:id/participants')
+  @ApiOperation({
+    summary: '참가자 목록 조회',
+    description: '특정 모각코에 참가한 모든 참가자 목록을 조회합니다.',
+  })
+  @ApiParam({ name: 'id', description: '참가자 목록을 조회할 모각코의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [ParticipantResponseDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getParticipants(@Param('id', ParseIntPipe) id: number): Promise<Member[]> {
+    return this.mogacoService.getParticipants(id);
   }
 }

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -103,4 +103,17 @@ export class MogacoController {
   async getParticipants(@Param('id', ParseIntPipe) id: number): Promise<Member[]> {
     return this.mogacoService.getParticipants(id);
   }
+
+  @Delete('/:id/join')
+  @ApiOperation({
+    summary: '모각코 참가 취소',
+    description: '특정 모각코 참가를 취소합니다.',
+  })
+  @ApiParam({ name: 'id', description: '참가를 취소할 모각코의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully cancelled join' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  async cancelMogacoJoin(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
+    return this.mogacoService.cancelMogacoJoin(id, member);
+  }
 }

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -101,4 +101,48 @@ export class MogacoRepository {
       throw new Error(`Failed to update Mogaco status: ${error.message}`);
     }
   }
+
+  async joinMogaco(id: number, member: Member): Promise<void> {
+    const mogaco = await this.prisma.mogaco.findUnique({
+      where: { id, deletedAt: null },
+    });
+
+    if (!mogaco) {
+      throw new NotFoundException(`Mogaco with id ${id} not found`);
+    }
+
+    const existingParticipant = await this.prisma.participant.findUnique({
+      where: {
+        postId_userId: {
+          postId: mogaco.id,
+          userId: member.id,
+        },
+      },
+    });
+
+    if (existingParticipant) {
+      throw new ForbiddenException(`Member with id ${member.id} is already participating in Mogaco with id ${id}`);
+    }
+
+    await this.prisma.participant.create({
+      data: {
+        postId: mogaco.id,
+        userId: member.id,
+      },
+    });
+  }
+
+  async getParticipants(id: number): Promise<Member[]> {
+    const participants = await this.prisma.participant.findMany({
+      where: {
+        postId: id,
+      },
+      include: {
+        member: true,
+      },
+    });
+
+    // 가져온 참가자 목록의 각 참가자의 member 속성을 통해 실제 멤버 객체로 매핑하여 반환
+    return participants.map((participant) => participant.member);
+  }
 }

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -102,6 +102,35 @@ export class MogacoRepository {
     }
   }
 
+  async updateMogaco(id: number, updateMogacoDto: CreateMogacoDto, member: Member): Promise<Mogaco> {
+    const mogaco = await this.prisma.mogaco.findUnique({
+      where: { id },
+    });
+
+    if (!mogaco) {
+      throw new NotFoundException(`Mogaco with id ${id} not found`);
+    }
+
+    if (mogaco.memberId !== member.id) {
+      throw new ForbiddenException(`You do not have permission to update this Mogaco`);
+    }
+
+    try {
+      return await this.prisma.mogaco.update({
+        where: { id: mogaco.id },
+        data: {
+          title: updateMogacoDto.title,
+          contents: updateMogacoDto.contents,
+          date: new Date(updateMogacoDto.date),
+          maxHumanCount: updateMogacoDto.maxHumanCount,
+          address: updateMogacoDto.address,
+        },
+      });
+    } catch (error) {
+      throw new Error(`Failed to update Mogaco: ${error.message}`);
+    }
+  }
+
   async joinMogaco(id: number, member: Member): Promise<void> {
     const mogaco = await this.prisma.mogaco.findUnique({
       where: { id, deletedAt: null },

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -37,4 +37,8 @@ export class MogacoService {
   async getParticipants(id: number): Promise<Member[]> {
     return this.mogacoRepository.getParticipants(id);
   }
+
+  async cancelMogacoJoin(id: number, member: Member): Promise<void> {
+    return this.mogacoRepository.cancelMogacoJoin(id, member);
+  }
 }

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -30,6 +30,10 @@ export class MogacoService {
     return this.mogacoRepository.updateMogacoStatus(mogaco);
   }
 
+  async updateMogaco(id: number, updateMogacoDto: CreateMogacoDto, member: Member) {
+    return this.mogacoRepository.updateMogaco(id, updateMogacoDto, member);
+  }
+
   async joinMogaco(id: number, member: Member): Promise<void> {
     return await this.mogacoRepository.joinMogaco(id, member);
   }

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -29,4 +29,12 @@ export class MogacoService {
     mogaco.status = status;
     return this.mogacoRepository.updateMogacoStatus(mogaco);
   }
+
+  async joinMogaco(id: number, member: Member): Promise<void> {
+    return await this.mogacoRepository.joinMogaco(id, member);
+  }
+
+  async getParticipants(id: number): Promise<Member[]> {
+    return this.mogacoRepository.getParticipants(id);
+  }
 }


### PR DESCRIPTION
## 설명
- close #142 

모각코에 다른 사용자들이 참가, 참가 취소, 참가자 확인하는 API를 작성합니다.

## 완료한 기능 명세
- [x] 모각코 참가
- [x] 모각코 참가 취소
- [x] 모각코 참가자 확인
- [x] Swagger

### 스크린샷
[스크린샷 기록소](https://ttaerrim.notion.site/381cd2ee87474cc090eac91309abf963?pvs=4)


## 리뷰 요청 사항
현재 Swagger 설정 부분 코드가 상당히 더럽습니다.
1차원적으로 깎지 않고 바로 작성했습니다.

chatGPT로 한번 깎아보려고 했는데 코드 바꾸고 swagger를 본 결과 많이 달라져서 Reset Hard 처리하였습니다..
우선 swagger를 짜는데 생각보다 체력과 안구에 힘이 드는 관계로 프로젝트 마무리 즈음에 코드 정리를 할 때 시도해보면 좋을 것 같습니다.

