### PR TITLE
[Feat] 모각코 상세 게시글 페이지 API 일부 구현

### DIFF
--- a/app/frontend/src/components/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/components/Mogaco/MogacoList.tsx
@@ -20,7 +20,6 @@ export function MogacoList() {
             title,
             contents,
             date,
-            participantList,
             maxHumanCount,
             address,
             status,
@@ -32,7 +31,6 @@ export function MogacoList() {
               title={title}
               groupId={groupId}
               contents={contents}
-              participantList={participantList}
               maxHumanCount={maxHumanCount}
               address={address}
               date={date}

--- a/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
@@ -23,20 +23,20 @@ export function DetailHeader({
   userHosted,
   userParticipated,
 }: DetailHeaderProps) {
-  const [user, setUser] = useState<UserInfo | null>(null);
+  const [hostUser, setHostUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
-    if (user) {
+    if (hostUser) {
       return;
     }
 
     const getUser = async () => {
       const data = await member.userInfoById(memberId);
-      setUser(data);
+      setHostUser(data);
     };
 
     getUser();
-  }, [user, memberId]);
+  }, [hostUser, memberId]);
 
   return (
     <div className={styles.header}>
@@ -50,9 +50,12 @@ export function DetailHeader({
           />
         </div>
       </div>
-      <div className={styles.writer}>
-        {user && (
-          <UserChip username={user.nickname} profileSrc={user.profilePicture} />
+      <div className={styles.hostUser}>
+        {hostUser && (
+          <UserChip
+            username={hostUser.nickname}
+            profileSrc={hostUser.profilePicture}
+          />
         )}
         <span>부스트캠프 웹·모바일 8기</span>
       </div>

--- a/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
@@ -9,6 +9,7 @@ import { DetailHeaderButtons } from './DetailHeaderButtons';
 import * as styles from './index.css';
 
 type DetailHeaderProps = {
+  id: string;
   memberId: string;
   title: string;
   status: '모집 중' | '마감' | '종료';
@@ -17,6 +18,7 @@ type DetailHeaderProps = {
 };
 
 export function DetailHeader({
+  id,
   memberId,
   title,
   status,
@@ -44,6 +46,7 @@ export function DetailHeader({
         <div className={sansBold24}>{title}</div>
         <div className={styles.buttons}>
           <DetailHeaderButtons
+            id={id}
             status={status}
             userHosted={userHosted}
             userParticipated={userParticipated}

--- a/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
@@ -12,9 +12,17 @@ type DetailHeaderProps = {
   memberId: string;
   title: string;
   status: '모집 중' | '마감' | '종료';
+  userHosted: boolean;
+  userParticipated: boolean;
 };
 
-export function DetailHeader({ memberId, title, status }: DetailHeaderProps) {
+export function DetailHeader({
+  memberId,
+  title,
+  status,
+  userHosted,
+  userParticipated,
+}: DetailHeaderProps) {
   const [user, setUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
@@ -35,7 +43,11 @@ export function DetailHeader({ memberId, title, status }: DetailHeaderProps) {
       <div className={styles.title}>
         <div className={sansBold24}>{title}</div>
         <div className={styles.buttons}>
-          <DetailHeaderButtons status={status} />
+          <DetailHeaderButtons
+            status={status}
+            userHosted={userHosted}
+            userParticipated={userParticipated}
+          />
         </div>
       </div>
       <div className={styles.writer}>

--- a/app/frontend/src/components/MogacoDetail/DetailHeaderButtons.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeaderButtons.tsx
@@ -34,13 +34,16 @@ const buttonComponents = {
 };
 
 type DetailHeaderButtonsProps = {
+  userHosted: boolean;
+  userParticipated: boolean;
   status: '모집 중' | '마감' | '종료';
 };
 
-export function DetailHeaderButtons({ status }: DetailHeaderButtonsProps) {
-  const userHosted = false;
-  const userParticipated = false;
-
+export function DetailHeaderButtons({
+  userHosted,
+  userParticipated,
+  status,
+}: DetailHeaderButtonsProps) {
   if (userHosted) {
     return buttonComponents.hosted;
   }

--- a/app/frontend/src/components/MogacoDetail/DetailHeaderButtons.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeaderButtons.tsx
@@ -1,58 +1,60 @@
 import { Button } from '@/components';
-
-const buttonComponents = {
-  participating: (
-    <Button theme="primary" shape="fill" size="large">
-      참석하기
-    </Button>
-  ),
-  participated: (
-    <>
-      <Button theme="primary" shape="fill" size="large">
-        채팅
-      </Button>
-      <Button theme="danger" shape="fill" size="large">
-        참석 취소
-      </Button>
-    </>
-  ),
-  hosted: (
-    <>
-      <Button theme="primary" shape="line" size="large">
-        수정
-      </Button>
-      <Button theme="danger" shape="line" size="large">
-        삭제
-      </Button>
-    </>
-  ),
-  closed: (
-    <Button theme="primary" shape="fill" size="large" disabled>
-      마감
-    </Button>
-  ),
-};
+import { mogaco } from '@/services';
 
 type DetailHeaderButtonsProps = {
+  id: string;
   userHosted: boolean;
   userParticipated: boolean;
   status: '모집 중' | '마감' | '종료';
 };
 
 export function DetailHeaderButtons({
+  id,
   userHosted,
   userParticipated,
   status,
 }: DetailHeaderButtonsProps) {
+  const onClickJoin = async () => {
+    await mogaco.join(id);
+  };
+
+  const onClickQuit = async () => {
+    await mogaco.quit(id);
+  };
+
   if (userHosted) {
-    return buttonComponents.hosted;
+    return (
+      <>
+        <Button theme="primary" shape="line" size="large">
+          수정
+        </Button>
+        <Button theme="danger" shape="line" size="large">
+          삭제
+        </Button>
+      </>
+    );
   }
 
   if (status === '모집 중') {
-    return userParticipated
-      ? buttonComponents.participated
-      : buttonComponents.participating;
+    return userParticipated ? (
+      <>
+        <Button theme="primary" shape="fill" size="large">
+          채팅
+        </Button>
+        <Button theme="danger" shape="fill" size="large" onClick={onClickQuit}>
+          참석 취소
+        </Button>
+      </>
+    ) : (
+      <Button theme="primary" shape="fill" size="large" onClick={onClickJoin}>
+        참석하기
+      </Button>
+    );
   }
 
-  return buttonComponents.closed;
+  return (
+    <Button theme="primary" shape="fill" size="large" disabled>
+      마감
+    </Button>
+  );
 }

--- a/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
@@ -14,7 +14,7 @@ import { Participant } from '@/types';
 import * as styles from './index.css';
 
 type DetailInfoProps = {
-  participantList: Participant[];
+  participantList: Participant[] | null;
   maxHumanCount: number;
   date: string;
   address: string;
@@ -36,7 +36,7 @@ export function DetailInfo({
       <div className={styles.infoItem}>
         <People fill={vars.color.grayscale200} />
         <span>
-          <span>{participantList.length}</span>/<span>{maxHumanCount}</span>
+          <span>{participantList?.length}</span>/<span>{maxHumanCount}</span>
         </span>
         <button
           type="button"
@@ -53,13 +53,14 @@ export function DetailInfo({
           participantsShown ? styles.shown : ''
         }`}
       >
-        {participantList.map((participant) => (
-          <UserChip
-            key={participant.id}
-            username={participant.nickname}
-            profileSrc={participant.profile}
-          />
-        ))}
+        {!!participantList &&
+          participantList.map((participant) => (
+            <UserChip
+              key={participant.id}
+              username={participant.nickname}
+              profileSrc={participant.profile}
+            />
+          ))}
       </div>
       <div className={styles.infoItem}>
         <Calendar fill={vars.color.grayscale200} />

--- a/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
@@ -58,7 +58,7 @@ export function DetailInfo({
             <UserChip
               key={participant.id}
               username={participant.nickname}
-              profileSrc={participant.profile}
+              profileSrc={participant.profilePicture}
             />
           ))}
       </div>

--- a/app/frontend/src/components/MogacoDetail/index.css.ts
+++ b/app/frontend/src/components/MogacoDetail/index.css.ts
@@ -31,6 +31,15 @@ export const horizontalLine = style({
   margin: 0,
 });
 
+export const hostUser = style([
+  sansBold16,
+  {
+    display: 'flex',
+    gap: '1.6rem',
+    color: vars.color.grayscale200,
+  },
+]);
+
 export const info = style({
   display: 'flex',
   flexDirection: 'column',
@@ -43,6 +52,8 @@ export const infoItem = style({
   alignItems: 'center',
 });
 
+const shown = style({});
+
 export const map = style({
   width: '32rem',
   height: '20rem',
@@ -50,8 +61,6 @@ export const map = style({
   borderRadius: '0.8rem',
   imageRendering: 'crisp-edges',
 });
-
-const shown = style({});
 
 export const participants = style({
   display: 'none',
@@ -94,12 +103,3 @@ export const wrapper = style({
   flexDirection: 'column',
   alignItems: 'center',
 });
-
-export const writer = style([
-  sansBold16,
-  {
-    display: 'flex',
-    gap: '1.6rem',
-    color: vars.color.grayscale200,
-  },
-]);

--- a/app/frontend/src/components/MogacoDetail/index.tsx
+++ b/app/frontend/src/components/MogacoDetail/index.tsx
@@ -24,7 +24,16 @@ export function MogacoDetailPage({
   const [participantList, setParticipantList] = useState<Participant[] | null>(
     null,
   );
-  const [user] = useUserAtom();
+  const [user, setUser] = useUserAtom();
+
+  if (!user)
+    setUser({
+      providerId: '1',
+      nickname: '지승',
+      profilePicture:
+        'https://avatars.githubusercontent.com/u/50646827?s=40&v=4',
+      email: 'js43og@gamil.com',
+    });
 
   const userHosted = user?.providerId === memberId;
   const userParticipated = participantList
@@ -50,6 +59,7 @@ export function MogacoDetailPage({
     <div className={styles.wrapper}>
       <div className={styles.container}>
         <DetailHeader
+          id={id}
           title={title}
           status={status}
           memberId={memberId}

--- a/app/frontend/src/components/MogacoDetail/index.tsx
+++ b/app/frontend/src/components/MogacoDetail/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import { mogaco } from '@/services';
+import { useUserAtom } from '@/stores';
 import { Mogaco, Participant } from '@/types';
 
 import { DetailContents } from './DetailContents';
@@ -20,7 +21,17 @@ export function MogacoDetailPage({
   contents,
   status,
 }: MogacoDetailProps) {
-  const [participantList, setParticipantList] = useState<Participant[]>([]);
+  const [participantList, setParticipantList] = useState<Participant[] | null>(
+    null,
+  );
+  const [user] = useUserAtom();
+
+  const userHosted = user?.providerId === memberId;
+  const userParticipated = participantList
+    ? !!participantList.find(
+        (participant) => participant.id === user?.providerId,
+      )
+    : false;
 
   useEffect(() => {
     if (participantList) {
@@ -38,7 +49,13 @@ export function MogacoDetailPage({
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>
-        <DetailHeader title={title} status={status} memberId={memberId} />
+        <DetailHeader
+          title={title}
+          status={status}
+          memberId={memberId}
+          userHosted={userHosted}
+          userParticipated={userParticipated}
+        />
         <DetailInfo
           participantList={participantList}
           maxHumanCount={maxHumanCount}

--- a/app/frontend/src/components/MogacoDetail/index.tsx
+++ b/app/frontend/src/components/MogacoDetail/index.tsx
@@ -1,4 +1,7 @@
-import { Mogaco } from '@/types';
+import { useState, useEffect } from 'react';
+
+import { mogaco } from '@/services';
+import { Mogaco, Participant } from '@/types';
 
 import { DetailContents } from './DetailContents';
 import { DetailHeader } from './DetailHeader';
@@ -8,15 +11,30 @@ import * as styles from './index.css';
 type MogacoDetailProps = Mogaco;
 
 export function MogacoDetailPage({
+  id,
   memberId,
   title,
   maxHumanCount,
-  participantList,
   date,
   address,
   contents,
   status,
 }: MogacoDetailProps) {
+  const [participantList, setParticipantList] = useState<Participant[]>([]);
+
+  useEffect(() => {
+    if (participantList) {
+      return;
+    }
+
+    const getParticipantList = async () => {
+      const data = await mogaco.participants(id);
+      setParticipantList(data);
+    };
+
+    getParticipantList();
+  }, [id, participantList]);
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>

--- a/app/frontend/src/components/commons/MogacoItem/index.tsx
+++ b/app/frontend/src/components/commons/MogacoItem/index.tsx
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 
 import { ReactComponent as Calendar } from '@/assets/icons/calendar.svg';
 import { ReactComponent as Map } from '@/assets/icons/map.svg';
-import { ReactComponent as People } from '@/assets/icons/people.svg';
 import { Label } from '@/components';
 import { Mogaco } from '@/types';
 
@@ -18,8 +17,6 @@ export function MogacoItem({
   title,
   contents,
   date,
-  participantList,
-  maxHumanCount,
   address,
   status,
 }: MogacoProps) {
@@ -39,12 +36,6 @@ export function MogacoItem({
       <div className={styles.content}>
         <div className={styles.detail}>{contents}</div>
         <div className={styles.info}>
-          <div className={styles.infoContent}>
-            <People className={styles.icon} />
-            <div className={styles.infoText}>
-              {participantList?.length || 0}/{maxHumanCount}
-            </div>
-          </div>
           <div className={styles.infoContent}>
             <Map className={styles.icon} />
             <div className={styles.infoText}>{address}</div>

--- a/app/frontend/src/mocks/members.ts
+++ b/app/frontend/src/mocks/members.ts
@@ -1,6 +1,24 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
+const userList = [
+  {
+    id: '1',
+    nickname: '지승',
+    profilePicture: 'https://avatars.githubusercontent.com/u/50646827?v=4',
+  },
+  {
+    id: '2',
+    nickname: '지원',
+    profilePicture: 'https://avatars.githubusercontent.com/u/110762136?v=4',
+  },
+  {
+    id: '3',
+    nickname: '태림',
+    profilePicture: 'https://avatars.githubusercontent.com/u/43867711?v=4',
+  },
+];
+
 export const memberAPIHandlers = [
   http.get(
     '/member/me',
@@ -17,13 +35,7 @@ export const memberAPIHandlers = [
   http.get(
     '/member/:id',
     // () => HttpResponse.error(),
-    () =>
-      HttpResponse.json({
-        providerId: '1',
-        email: 'js43og@gmail.com',
-        nickname: '지승',
-        profilePicture:
-          'https://avatars.githubusercontent.com/u/50646827?s=64&v=4',
-      }),
+    ({ params: { id } }) => HttpResponse.json(userList[Number(id) - 1]),
   ),
 ];
+export { userList };

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -3,90 +3,70 @@ import { http, HttpResponse } from 'msw';
 
 import { Mogaco, Participant } from '@/types';
 
+import { userList } from './members';
+
+const mogacoList = [
+  {
+    id: '1',
+    groupId: '1',
+    memberId: '1',
+    title: '인천역 모각코',
+    contents: '인천에서 같이 모각코 하실 분을 모십니다.',
+    date: '2023-11-22T12:00:00.000Z',
+    maxHumanCount: 5,
+    address: '서울 관악구 어디길 어디로 뭐시기카페',
+    status: '모집 중' as const,
+  },
+  {
+    id: '2',
+    groupId: '1',
+    memberId: '2',
+    title: '이수역 모각코',
+    contents: '이수역 모각코 하실 분 구합니다!',
+    date: '2023-11-22T12:00:00.000Z',
+    maxHumanCount: 5,
+    address: '주소주소주소주소주소',
+    status: '마감' as const,
+  },
+  {
+    id: '3',
+    groupId: '1',
+    memberId: '3',
+    title: '종각역 모각코',
+    contents: '종각역에서 모각코 하실 분 구해요',
+    date: '2023-10-11T12:00:00.000Z',
+    maxHumanCount: 5,
+    address: '주소주소주소주소주소',
+    status: '종료' as const,
+  },
+  {
+    id: '4',
+    groupId: '1',
+    memberId: '1',
+    title: '사당역 모각코',
+    contents: '사당역 크레이저 커피로 오세요~',
+    date: '2023-11-22T12:00:00.000Z',
+    maxHumanCount: 5,
+    address: '주소주소주소주소주소',
+    status: '모집 중' as const,
+  },
+];
+
+const participantsList = [
+  [userList[0], userList[1], userList[2]],
+  [userList[1], userList[2]],
+  [userList[0], userList[2]],
+  [userList[0], userList[1]],
+];
+
 export const mogacoAPIHandlers = [
-  http.get('/mogaco', () =>
-    HttpResponse.json<Mogaco[]>([
-      {
-        id: '1',
-        groupId: '12314',
-        memberId: '1',
-        title: '사당역 모각코',
-        contents:
-          '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
-        date: '2023-11-22T12:00:00.000Z',
-        maxHumanCount: 5,
-        address: '서울 관악구 어디길 어디로 뭐시기카페',
-        status: '모집 중',
-      },
-      {
-        id: '2',
-        groupId: '12314',
-        memberId: '1',
-        title: '사당역 모각코',
-        contents:
-          '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
-        date: '2023-11-22T12:00:00.000Z',
-        maxHumanCount: 5,
-        address: '주소주소주소주소주소',
-        status: '모집 중',
-      },
-      {
-        id: '3',
-        groupId: '12314',
-        memberId: '1',
-        title: '사당역 모각코',
-        contents:
-          '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
-        date: '2023-11-22T12:00:00.000Z',
-        maxHumanCount: 5,
-        address: '주소주소주소주소주소',
-        status: '모집 중',
-      },
-      {
-        id: '4',
-        groupId: '12314',
-        memberId: '1',
-        title: '사당역 모각코',
-        contents:
-          '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
-        date: '2023-11-22T12:00:00.000Z',
-        maxHumanCount: 5,
-        address: '주소주소주소주소주소',
-        status: '모집 중',
-      },
-    ]),
+  http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
+  http.get('/mogaco/:id', ({ params: { id } }) =>
+    HttpResponse.json<Mogaco>(mogacoList[Number(id) - 1]),
   ),
-  http.get('/mogaco/:id', () =>
-    HttpResponse.json<Mogaco>({
-      id: '1',
-      groupId: '1',
-      memberId: '1',
-      title: '사당역에서 모각코 하실 분~',
-      contents:
-        '내일 오후 2시 사당역 크레이저 커피에서 같이 모각코 하실 분을 모십니다.',
-      date: '2023-11-22 16:22',
-      maxHumanCount: 5,
-      address: '서울 관악구 남현3길 71 크레이저 커피',
-      status: '모집 중',
-    }),
+  http.get('/mogaco/:id/participants', ({ params: { id } }) =>
+    HttpResponse.json<Participant[]>(participantsList[Number(id) - 1]),
   ),
-  http.get('/mogaco/:id/participants', () =>
-    HttpResponse.json<Participant[]>([
-      {
-        id: '1',
-        nickname: '지승',
-        profile: 'https://avatars.githubusercontent.com/u/50646827?v=4',
-      },
-      {
-        id: '2',
-        nickname: '지원',
-        profile: 'https://avatars.githubusercontent.com/u/110762136?v=4',
-      },
-      {
-        id: '3',
-        nickname: '태림',
-        profile: 'https://avatars.githubusercontent.com/u/43867711?v=4',
-      },
-    ]),
-  ),
+  http.post('mogaco/:id/join', () => {}),
+  http.delete('mogaco/:id/join', () => {}),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -26,7 +26,7 @@ const mogacoList = [
     date: '2023-11-22T12:00:00.000Z',
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
-    status: '마감' as const,
+    status: '모집 중' as const,
   },
   {
     id: '3',
@@ -37,7 +37,7 @@ const mogacoList = [
     date: '2023-10-11T12:00:00.000Z',
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
-    status: '종료' as const,
+    status: '모집 중' as const,
   },
   {
     id: '4',
@@ -67,15 +67,17 @@ export const mogacoAPIHandlers = [
   http.get('/mogaco/:id/participants', ({ params: { id } }) =>
     HttpResponse.json<Participant[]>(participantsList[Number(id) - 1]),
   ),
-  http.post('mogaco/:id/join', async ({ params: { id } }) => {
+  http.post('/mogaco/:id/join', ({ params: { id } }) => {
     participantsList[Number(id) - 1] = [
       ...participantsList[Number(id) - 1],
       userList[0],
     ];
+    return HttpResponse.json(null, { status: 200 });
   }),
-  http.delete('mogaco/:id/join', async ({ params: { id } }) => {
+  http.delete('/mogaco/:id/join', ({ params: { id } }) => {
     participantsList[Number(id) - 1] = participantsList[Number(id) - 1].filter(
       (participant) => participant.id !== userList[0].id,
     );
+    return HttpResponse.json(null, { status: 200 });
   }),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -67,6 +67,23 @@ export const mogacoAPIHandlers = [
   http.get('/mogaco/:id/participants', ({ params: { id } }) =>
     HttpResponse.json<Participant[]>(participantsList[Number(id) - 1]),
   ),
-  http.post('mogaco/:id/join', () => {}),
-  http.delete('mogaco/:id/join', () => {}),
+  http.post<{ id: string }, { memberId: string }>(
+    'mogaco/:id/join',
+    async ({ request, params: { id } }) => {
+      const { memberId } = await request.json();
+      participantsList[Number(id) - 1] = [
+        ...participantsList[Number(id) - 1],
+        userList[Number(memberId) - 1],
+      ];
+    },
+  ),
+  http.delete<{ id: string }, { memberId: string }>(
+    'mogaco/:id/join',
+    async ({ request, params: { id } }) => {
+      const { memberId } = await request.json();
+      participantsList[Number(id) - 1] = participantsList[
+        Number(id) - 1
+      ].filter((participant) => participant.id !== memberId);
+    },
+  ),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
-import { Mogaco } from '@/types';
+import { Mogaco, Participant } from '@/types';
 
 export const mogacoAPIHandlers = [
   http.get('/mogaco', () =>
-    HttpResponse.json([
+    HttpResponse.json<Mogaco[]>([
       {
         id: '1',
         groupId: '12314',
@@ -14,20 +14,6 @@ export const mogacoAPIHandlers = [
         contents:
           '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
         date: '2023-11-22T12:00:00.000Z',
-        participantList: [
-          {
-            id: '123',
-            nickname: 'Rimi',
-            profile:
-              'https://lh3.googleusercontent.com/ogw/AKPQZvwTnGmjh0sydCnI53wZMYLcKf-KZJ7Z9MaLg1ZVLQ=s64-c-mo',
-          },
-          {
-            id: '123',
-            nickname: 'Rimi',
-            profile:
-              'https://lh3.googleusercontent.com/ogw/AKPQZvwTnGmjh0sydCnI53wZMYLcKf-KZJ7Z9MaLg1ZVLQ=s64-c-mo',
-          },
-        ],
         maxHumanCount: 5,
         address: '서울 관악구 어디길 어디로 뭐시기카페',
         status: '모집 중',
@@ -40,7 +26,6 @@ export const mogacoAPIHandlers = [
         contents:
           '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
         date: '2023-11-22T12:00:00.000Z',
-        participantList: [],
         maxHumanCount: 5,
         address: '주소주소주소주소주소',
         status: '모집 중',
@@ -53,14 +38,6 @@ export const mogacoAPIHandlers = [
         contents:
           '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
         date: '2023-11-22T12:00:00.000Z',
-        participantList: [
-          {
-            id: '123',
-            nickname: 'Rimi',
-            profile:
-              'https://lh3.googleusercontent.com/ogw/AKPQZvwTnGmjh0sydCnI53wZMYLcKf-KZJ7Z9MaLg1ZVLQ=s64-c-mo',
-          },
-        ],
         maxHumanCount: 5,
         address: '주소주소주소주소주소',
         status: '모집 중',
@@ -73,7 +50,6 @@ export const mogacoAPIHandlers = [
         contents:
           '사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 사당역 모각코 ',
         date: '2023-11-22T12:00:00.000Z',
-        participantList: [],
         maxHumanCount: 5,
         address: '주소주소주소주소주소',
         status: '모집 중',
@@ -89,26 +65,28 @@ export const mogacoAPIHandlers = [
       contents:
         '내일 오후 2시 사당역 크레이저 커피에서 같이 모각코 하실 분을 모십니다.',
       date: '2023-11-22 16:22',
-      participantList: [
-        {
-          id: '1',
-          nickname: '지승',
-          profile: 'https://avatars.githubusercontent.com/u/50646827?v=4',
-        },
-        {
-          id: '2',
-          nickname: '지원',
-          profile: 'https://avatars.githubusercontent.com/u/110762136?v=4',
-        },
-        {
-          id: '3',
-          nickname: '태림',
-          profile: 'https://avatars.githubusercontent.com/u/43867711?v=4',
-        },
-      ],
       maxHumanCount: 5,
       address: '서울 관악구 남현3길 71 크레이저 커피',
       status: '모집 중',
     }),
+  ),
+  http.get('/mogaco/:id/participants', () =>
+    HttpResponse.json<Participant[]>([
+      {
+        id: '1',
+        nickname: '지승',
+        profile: 'https://avatars.githubusercontent.com/u/50646827?v=4',
+      },
+      {
+        id: '2',
+        nickname: '지원',
+        profile: 'https://avatars.githubusercontent.com/u/110762136?v=4',
+      },
+      {
+        id: '3',
+        nickname: '태림',
+        profile: 'https://avatars.githubusercontent.com/u/43867711?v=4',
+      },
+    ]),
   ),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -67,23 +67,15 @@ export const mogacoAPIHandlers = [
   http.get('/mogaco/:id/participants', ({ params: { id } }) =>
     HttpResponse.json<Participant[]>(participantsList[Number(id) - 1]),
   ),
-  http.post<{ id: string }, { memberId: string }>(
-    'mogaco/:id/join',
-    async ({ request, params: { id } }) => {
-      const { memberId } = await request.json();
-      participantsList[Number(id) - 1] = [
-        ...participantsList[Number(id) - 1],
-        userList[Number(memberId) - 1],
-      ];
-    },
-  ),
-  http.delete<{ id: string }, { memberId: string }>(
-    'mogaco/:id/join',
-    async ({ request, params: { id } }) => {
-      const { memberId } = await request.json();
-      participantsList[Number(id) - 1] = participantsList[
-        Number(id) - 1
-      ].filter((participant) => participant.id !== memberId);
-    },
-  ),
+  http.post('mogaco/:id/join', async ({ params: { id } }) => {
+    participantsList[Number(id) - 1] = [
+      ...participantsList[Number(id) - 1],
+      userList[0],
+    ];
+  }),
+  http.delete('mogaco/:id/join', async ({ params: { id } }) => {
+    participantsList[Number(id) - 1] = participantsList[Number(id) - 1].filter(
+      (participant) => participant.id !== userList[0].id,
+    );
+  }),
 ];

--- a/app/frontend/src/pages/MogacoDetail/index.tsx
+++ b/app/frontend/src/pages/MogacoDetail/index.tsx
@@ -1,33 +1,35 @@
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { MogacoDetailPage } from '@/components';
 import { mogaco } from '@/services';
 import { Mogaco } from '@/types';
 
 export function MogacoDetail() {
+  const { id } = useParams();
   const [mogacoData, setMogacoData] = useState<Mogaco | null>(null);
 
   useEffect(() => {
-    if (mogacoData) return;
+    if (!id || mogacoData) {
+      return;
+    }
 
     const fetchMogacoData = async () => {
-      const data = await mogaco.detail();
+      const data = await mogaco.detail(id);
       setMogacoData(data);
     };
 
     fetchMogacoData();
-  }, [mogacoData]);
+  }, [id, mogacoData]);
 
   if (!mogacoData) {
     return <div>불러오는 중...</div>;
   }
 
   const {
-    id,
     memberId,
     groupId,
     title,
-    participantList,
     maxHumanCount,
     date,
     address,
@@ -37,11 +39,10 @@ export function MogacoDetail() {
 
   return (
     <MogacoDetailPage
-      id={id}
+      id={id as string}
       memberId={memberId}
       groupId={groupId}
       title={title}
-      participantList={participantList}
       maxHumanCount={maxHumanCount}
       date={date}
       address={address}

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -21,4 +21,10 @@ export const mogaco = {
     );
     return data;
   },
+  join: async (id: string) => {
+    await morakAPI.post(`/mogaco/${id}/join`);
+  },
+  quit: async (id: string) => {
+    await morakAPI.delete(`/mogaco/${id}/join`);
+  },
 };

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -1,19 +1,24 @@
-import { Mogaco } from '@/types';
+import { Mogaco, Participant } from '@/types';
 
 import { morakAPI } from './morakAPI';
 
 export const mogaco = {
   endPoint: {
     list: '/mogaco',
-    detail: '/mogaco/:id',
   },
 
   list: async () => {
     const { data } = await morakAPI.get<Mogaco[]>(mogaco.endPoint.list);
     return data;
   },
-  detail: async () => {
-    const { data } = await morakAPI.get<Mogaco>(mogaco.endPoint.detail);
+  detail: async (id: string) => {
+    const { data } = await morakAPI.get<Mogaco>(`/mogaco/${id}`);
+    return data;
+  },
+  participants: async (id: string) => {
+    const { data } = await morakAPI.get<Participant[]>(
+      `/mogaco/${id}/participants`,
+    );
     return data;
   },
 };

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -9,7 +9,7 @@ interface MogacoTypes {
   address: string;
   status: '모집 중' | '마감' | '종료';
   nickname: string;
-  profile: string;
+  profilePicture: string;
 }
 
 export type Mogaco = Pick<
@@ -20,7 +20,6 @@ export type Mogaco = Pick<
   | 'title'
   | 'contents'
   | 'date'
-  | 'participantList'
   | 'maxHumanCount'
   | 'address'
   | 'status'
@@ -37,4 +36,7 @@ export type MogacoPostForm = Pick<
   | 'address'
 >;
 
-export type Participant = Pick<MogacoTypes, 'id' | 'nickname' | 'profile'>;
+export type Participant = Pick<
+  MogacoTypes,
+  'id' | 'nickname' | 'profilePicture'
+>;

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -5,7 +5,6 @@ interface MogacoTypes {
   title: string;
   contents: string;
   date: string;
-  participantList: Participant[];
   maxHumanCount: number;
   address: string;
   status: '모집 중' | '마감' | '종료';


### PR DESCRIPTION
## 설명
- close #149 

## 완료한 기능 명세
- [x] 사용자의 상태에 따라 버튼 분기 렌더링
- [x] 모각코 미참여자인 경우 '참석하기' 기능 구현
- [x] 모각코 참여자인 경우 '참석 취소' 기능 구현

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
- 현재 사용자의 상태는 jotai를 통한 전역 상태에 있다고 가정했습니다.
- 참석하기/참석 취소 기능을 위해 mock 데이터를 객체로 분리했습니다.
- 위 두 기능에 대한 API 호출 후 리렌더링되지 않는 상태입니다. (결과를 확인하려면 해당 페이지를 직접 다시 불러와야 합니다, (나갔다 들어오기))
- `/mogaco/:id/participants` API 분리 반영했습니다.

