### PR TITLE
[Feat] 모각코 상세 게시글 페이지 API 연동

### DIFF
--- a/app/frontend/src/components/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/components/Mogaco/MogacoList.tsx
@@ -15,7 +15,6 @@ export function MogacoList() {
         mogacoList.map(
           ({
             id,
-            memberId,
             groupId,
             title,
             contents,
@@ -27,7 +26,6 @@ export function MogacoList() {
             <MogacoItem
               key={id}
               id={id}
-              memberId={memberId}
               title={title}
               groupId={groupId}
               contents={contents}

--- a/app/frontend/src/components/MogacoDetail/DetailContents.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailContents.tsx
@@ -1,7 +1,0 @@
-type DetailContentsProps = {
-  contents: string;
-};
-
-export function DetailContents({ contents }: DetailContentsProps) {
-  return <div>{contents}</div>;
-}

--- a/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { UserChip } from '@/components';
 import { member } from '@/services';
 import { sansBold24 } from '@/styles/font.css';
-import { UserInfo } from '@/types';
+import { Member } from '@/types';
 
 import { DetailHeaderButtons } from './DetailHeaderButtons';
 import * as styles from './index.css';
@@ -25,7 +25,7 @@ export function DetailHeader({
   userHosted,
   userParticipated,
 }: DetailHeaderProps) {
-  const [hostUser, setHostUser] = useState<UserInfo | null>(null);
+  const [hostUser, setHostUser] = useState<Member | null>(null);
 
   useEffect(() => {
     if (hostUser) {
@@ -33,7 +33,7 @@ export function DetailHeader({
     }
 
     const getUser = async () => {
-      const data = await member.userInfoById(memberId);
+      const data = await member.infoById(memberId);
       setHostUser(data);
     };
 

--- a/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailHeader.tsx
@@ -1,65 +1,41 @@
-import { useState, useEffect } from 'react';
-
 import { UserChip } from '@/components';
-import { member } from '@/services';
 import { sansBold24 } from '@/styles/font.css';
-import { Member } from '@/types';
+import { Member, Mogaco } from '@/types';
 
 import { DetailHeaderButtons } from './DetailHeaderButtons';
 import * as styles from './index.css';
 
 type DetailHeaderProps = {
   id: string;
-  memberId: string;
-  title: string;
-  status: '모집 중' | '마감' | '종료';
-  userHosted: boolean;
-  userParticipated: boolean;
+  currentUser: Member;
+  mogacoData: Mogaco;
+  participantList: Member[];
 };
 
 export function DetailHeader({
   id,
-  memberId,
-  title,
-  status,
-  userHosted,
-  userParticipated,
+  currentUser,
+  mogacoData,
+  participantList,
 }: DetailHeaderProps) {
-  const [hostUser, setHostUser] = useState<Member | null>(null);
-
-  useEffect(() => {
-    if (hostUser) {
-      return;
-    }
-
-    const getUser = async () => {
-      const data = await member.infoById(memberId);
-      setHostUser(data);
-    };
-
-    getUser();
-  }, [hostUser, memberId]);
-
   return (
     <div className={styles.header}>
       <div className={styles.title}>
-        <div className={sansBold24}>{title}</div>
+        <div className={sansBold24}>{mogacoData.title}</div>
         <div className={styles.buttons}>
           <DetailHeaderButtons
             id={id}
-            status={status}
-            userHosted={userHosted}
-            userParticipated={userParticipated}
+            currentUser={currentUser}
+            mogacoData={mogacoData}
+            participantList={participantList}
           />
         </div>
       </div>
       <div className={styles.hostUser}>
-        {hostUser && (
-          <UserChip
-            username={hostUser.nickname}
-            profileSrc={hostUser.profilePicture}
-          />
-        )}
+        <UserChip
+          username={mogacoData.member.nickname}
+          profileSrc={mogacoData.member.profilePicture}
+        />
         <span>부스트캠프 웹·모바일 8기</span>
       </div>
     </div>

--- a/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/components/MogacoDetail/DetailInfo.tsx
@@ -9,23 +9,16 @@ import { ReactComponent as People } from '@/assets/icons/people_large.svg';
 import { UserChip } from '@/components';
 import { MAP_SAMPLE_IMAGE } from '@/constants';
 import { vars } from '@/styles';
-import { Participant } from '@/types';
+import { Member, Mogaco } from '@/types';
 
 import * as styles from './index.css';
 
 type DetailInfoProps = {
-  participantList: Participant[] | null;
-  maxHumanCount: number;
-  date: string;
-  address: string;
+  mogacoData: Mogaco;
+  participantList: Member[];
 };
 
-export function DetailInfo({
-  participantList,
-  maxHumanCount,
-  date,
-  address,
-}: DetailInfoProps) {
+export function DetailInfo({ mogacoData, participantList }: DetailInfoProps) {
   const [participantsShown, setParticipantsShown] = useState(false);
 
   const toggleParticipantsShown = () =>
@@ -36,7 +29,8 @@ export function DetailInfo({
       <div className={styles.infoItem}>
         <People fill={vars.color.grayscale200} />
         <span>
-          <span>{participantList?.length}</span>/<span>{maxHumanCount}</span>
+          <span>{participantList.length}</span>/
+          <span>{mogacoData.maxHumanCount}</span>
         </span>
         <button
           type="button"
@@ -56,7 +50,7 @@ export function DetailInfo({
         {!!participantList &&
           participantList.map((participant) => (
             <UserChip
-              key={participant.id}
+              key={participant.providerId}
               username={participant.nickname}
               profileSrc={participant.profilePicture}
             />
@@ -64,11 +58,11 @@ export function DetailInfo({
       </div>
       <div className={styles.infoItem}>
         <Calendar fill={vars.color.grayscale200} />
-        <span>{dayjs(date).format('YYYY/MM/DD HH:mm~')}</span>
+        <span>{dayjs(mogacoData.date).format('YYYY/MM/DD HH:mm~')}</span>
       </div>
       <div className={styles.infoItem}>
         <Map fill={vars.color.grayscale200} />
-        <span>{address}</span>
+        <span>{mogacoData.address}</span>
       </div>
       <img src={MAP_SAMPLE_IMAGE} alt="맵 샘플 이미지" className={styles.map} />
     </div>

--- a/app/frontend/src/components/MogacoDetail/index.tsx
+++ b/app/frontend/src/components/MogacoDetail/index.tsx
@@ -13,9 +13,13 @@ export function MogacoDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
 
-  const { data: currentUser } = useQuery(queryKeys.member.me());
-  const { data: mogacoData } = useQuery(queryKeys.mogaco.detail(id!));
-  const { data: participantList } = useQuery(
+  const { data: currentUser, isLoading: currentUserLoading } = useQuery(
+    queryKeys.member.me(),
+  );
+  const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery(
+    queryKeys.mogaco.detail(id!),
+  );
+  const { data: participantList, isLoading: participantListLoading } = useQuery(
     queryKeys.mogaco.participants(id!),
   );
 
@@ -27,8 +31,12 @@ export function MogacoDetailPage() {
     }
   }, [currentUser, navigate]);
 
-  if (!mogacoData || !participantList) {
+  if (currentUserLoading || mogacoDataLoading || participantListLoading) {
     return <div>로딩 중...</div>;
+  }
+
+  if (!mogacoData) {
+    return <div>정보를 불러오는 데에 실패했습니다.</div>;
   }
 
   return (
@@ -38,9 +46,12 @@ export function MogacoDetailPage() {
           id={id!}
           currentUser={currentUser!}
           mogacoData={mogacoData}
-          participantList={participantList}
+          participantList={participantList || []}
         />
-        <DetailInfo mogacoData={mogacoData} participantList={participantList} />
+        <DetailInfo
+          mogacoData={mogacoData}
+          participantList={participantList || []}
+        />
         <div>{mogacoData.contents}</div>
         <hr className={styles.horizontalLine} />
       </div>

--- a/app/frontend/src/components/MogacoDetail/index.tsx
+++ b/app/frontend/src/components/MogacoDetail/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import { useQuery } from '@tanstack/react-query';
@@ -10,7 +11,7 @@ import * as styles from './index.css';
 
 export function MogacoDetailPage() {
   const { id } = useParams();
-  const navigator = useNavigate();
+  const navigate = useNavigate();
 
   const { data: currentUser } = useQuery(queryKeys.member.me());
   const { data: mogacoData } = useQuery(queryKeys.mogaco.detail(id!));
@@ -18,12 +19,13 @@ export function MogacoDetailPage() {
     queryKeys.mogaco.participants(id!),
   );
 
-  if (!currentUser) {
-    // eslint-disable-next-line no-alert
-    window.alert('인증 정보가 없습니다.\n로그인해 주세요.');
-    navigator('/');
-    return <div>리다이렉션...</div>;
-  }
+  useEffect(() => {
+    if (!currentUser) {
+      // eslint-disable-next-line no-alert
+      window.alert('인증 정보가 없습니다.\n로그인해 주세요.');
+      navigate('/');
+    }
+  }, [currentUser, navigate]);
 
   if (!mogacoData || !participantList) {
     return <div>로딩 중...</div>;
@@ -34,7 +36,7 @@ export function MogacoDetailPage() {
       <div className={styles.container}>
         <DetailHeader
           id={id!}
-          currentUser={currentUser}
+          currentUser={currentUser!}
           mogacoData={mogacoData}
           participantList={participantList}
         />

--- a/app/frontend/src/components/commons/MogacoItem/index.tsx
+++ b/app/frontend/src/components/commons/MogacoItem/index.tsx
@@ -9,7 +9,7 @@ import { Mogaco } from '@/types';
 
 import * as styles from './index.css';
 
-type MogacoProps = Mogaco;
+type MogacoProps = Omit<Mogaco, 'member'>;
 
 export function MogacoItem({
   id,

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import { queryKeys } from './queries';
 
 async function enableMocking() {
   if (import.meta.env.MODE !== 'development') {
@@ -18,6 +19,9 @@ async function enableMocking() {
 }
 
 const queryClient = new QueryClient();
+queryClient.setQueryDefaults(queryKeys.member.me().queryKey, {
+  staleTime: Infinity,
+});
 
 enableMocking().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/app/frontend/src/mocks/members.ts
+++ b/app/frontend/src/mocks/members.ts
@@ -1,19 +1,24 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
-const userList = [
+import { Member } from '@/types';
+
+const memberList: Member[] = [
   {
-    id: '1',
+    providerId: '1',
+    email: '.',
     nickname: '지승',
     profilePicture: 'https://avatars.githubusercontent.com/u/50646827?v=4',
   },
   {
-    id: '2',
+    providerId: '2',
+    email: '.',
     nickname: '지원',
     profilePicture: 'https://avatars.githubusercontent.com/u/110762136?v=4',
   },
   {
-    id: '3',
+    providerId: '3',
+    email: '.',
     nickname: '태림',
     profilePicture: 'https://avatars.githubusercontent.com/u/43867711?v=4',
   },
@@ -23,19 +28,13 @@ export const memberAPIHandlers = [
   http.get(
     '/member/me',
     // () => HttpResponse.error(),
-    () =>
-      HttpResponse.json({
-        providerId: '1234',
-        email: 'ttrrr121@gmail.com',
-        nickname: 'RIMI',
-        profilePicture:
-          'https://lh3.googleusercontent.com/ogw/AKPQZvwTnGmjh0sydCnI53wZMYLcKf-KZJ7Z9MaLg1ZVLQ=s64-c-mo',
-      }),
+    () => HttpResponse.json(memberList[0]),
   ),
   http.get(
     '/member/:id',
     // () => HttpResponse.error(),
-    ({ params: { id } }) => HttpResponse.json(userList[Number(id) - 1]),
+    ({ params: { id } }) => HttpResponse.json(memberList[Number(id) - 1]),
   ),
 ];
-export { userList };
+
+export { memberList };

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -61,6 +61,7 @@ const participantsList = [
 
 export const mogacoAPIHandlers = [
   http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
+  http.delete('/mogaco/:id', () => HttpResponse.json(null, { status: 200 })),
   http.get('/mogaco/:id', ({ params: { id } }) =>
     HttpResponse.json<Mogaco>(mogacoList[Number(id) - 1]),
   ),
@@ -81,5 +82,4 @@ export const mogacoAPIHandlers = [
     );
     return HttpResponse.json(null, { status: 200 });
   }),
-  http.delete('/mogaco/:id', () => HttpResponse.json(null, { status: 200 })),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -1,84 +1,84 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
-import { Mogaco, Participant } from '@/types';
+import { Member, Mogaco } from '@/types';
 
-import { userList } from './members';
+import { memberList } from './members';
 
-const mogacoList = [
+const mogacoList: Mogaco[] = [
   {
     id: '1',
     groupId: 1,
-    memberId: '1',
     title: '인천역 모각코',
     contents: '인천에서 같이 모각코 하실 분을 모십니다.',
     date: '2023-11-22T12:00:00.000Z',
     maxHumanCount: 5,
     address: '서울 관악구 어디길 어디로 뭐시기카페',
     status: '모집 중' as const,
+    member: memberList[0],
   },
   {
     id: '2',
     groupId: 1,
-    memberId: '2',
     title: '이수역 모각코',
     contents: '이수역 모각코 하실 분 구합니다!',
     date: '2023-11-22T12:00:00.000Z',
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
+    member: memberList[1],
   },
   {
     id: '3',
     groupId: 1,
-    memberId: '3',
     title: '종각역 모각코',
     contents: '종각역에서 모각코 하실 분 구해요',
     date: '2023-10-11T12:00:00.000Z',
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
+    member: memberList[2],
   },
   {
     id: '4',
     groupId: 1,
-    memberId: '1',
     title: '사당역 모각코',
     contents: '사당역 크레이저 커피로 오세요~',
     date: '2023-11-22T12:00:00.000Z',
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
+    member: memberList[1],
   },
 ];
 
-const participantsList = [
-  [userList[0], userList[1], userList[2]],
-  [userList[1], userList[2]],
-  [userList[0], userList[2]],
-  [userList[0], userList[1]],
+const participantsList: Member[][] = [
+  [memberList[0], memberList[1], memberList[2]],
+  [memberList[1], memberList[2]],
+  [memberList[0], memberList[2]],
+  [memberList[0], memberList[1]],
 ];
 
 export const mogacoAPIHandlers = [
   http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
+  http.post('/mogaco', () => HttpResponse.json(null, { status: 200 })),
   http.delete('/mogaco/:id', () => HttpResponse.json(null, { status: 200 })),
   http.get('/mogaco/:id', ({ params: { id } }) =>
     HttpResponse.json<Mogaco>(mogacoList[Number(id) - 1]),
   ),
   http.get('/mogaco/:id/participants', ({ params: { id } }) =>
-    HttpResponse.json<Participant[]>(participantsList[Number(id) - 1]),
+    HttpResponse.json<Member[]>(participantsList[Number(id) - 1]),
   ),
-  http.post('/mogaco', () => HttpResponse.json(null, { status: 201 })),
   http.post('/mogaco/:id/join', ({ params: { id } }) => {
     participantsList[Number(id) - 1] = [
       ...participantsList[Number(id) - 1],
-      userList[0],
+      memberList[0],
     ];
     return HttpResponse.json(null, { status: 200 });
   }),
   http.delete('/mogaco/:id/join', ({ params: { id } }) => {
     participantsList[Number(id) - 1] = participantsList[Number(id) - 1].filter(
-      (participant) => participant.id !== userList[0].id,
+      (participant) => participant.providerId !== memberList[0].providerId,
     );
     return HttpResponse.json(null, { status: 200 });
   }),

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -5,7 +5,7 @@ import { Member, Mogaco } from '@/types';
 
 import { memberList } from './members';
 
-const mogacoList: Mogaco[] = [
+let mogacoList: Mogaco[] = [
   {
     id: '1',
     groupId: 1,
@@ -26,7 +26,7 @@ const mogacoList: Mogaco[] = [
     maxHumanCount: 5,
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
-    member: memberList[1],
+    member: memberList[2],
   },
   {
     id: '3',
@@ -52,34 +52,46 @@ const mogacoList: Mogaco[] = [
   },
 ];
 
-const participantsList: Member[][] = [
-  [memberList[0], memberList[1], memberList[2]],
-  [memberList[1], memberList[2]],
-  [memberList[0], memberList[2]],
-  [memberList[0], memberList[1]],
+const participantsList: { id: string; participants: Member[] }[] = [
+  { id: '1', participants: [memberList[0], memberList[1], memberList[2]] },
+  { id: '2', participants: [memberList[0], memberList[2]] },
+  { id: '3', participants: [memberList[1], memberList[2]] },
+  { id: '4', participants: [memberList[0], memberList[1]] },
 ];
 
 export const mogacoAPIHandlers = [
   http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
-  http.post('/mogaco', () => HttpResponse.json(null, { status: 200 })),
-  http.delete('/mogaco/:id', () => HttpResponse.json(null, { status: 200 })),
+  http.post('/mogaco', () => HttpResponse.json({ status: 201 })),
   http.get('/mogaco/:id', ({ params: { id } }) =>
-    HttpResponse.json<Mogaco>(mogacoList[Number(id) - 1]),
+    HttpResponse.json<Mogaco>(mogacoList.find((mogaco) => mogaco.id === id)),
   ),
+  http.delete('/mogaco/:id', ({ params: { id } }) => {
+    mogacoList = mogacoList.filter((mogaco) => mogaco.id !== id);
+    return HttpResponse.json({ status: 204 });
+  }),
   http.get('/mogaco/:id/participants', ({ params: { id } }) =>
-    HttpResponse.json<Member[]>(participantsList[Number(id) - 1]),
+    HttpResponse.json<Member[]>(
+      participantsList.find((item) => item.id === id)?.participants,
+    ),
   ),
   http.post('/mogaco/:id/join', ({ params: { id } }) => {
-    participantsList[Number(id) - 1] = [
-      ...participantsList[Number(id) - 1],
-      memberList[0],
-    ];
-    return HttpResponse.json(null, { status: 200 });
+    const target = participantsList.find((item) => item.id === id);
+    if (!target) {
+      return HttpResponse.json({ status: 404 });
+    }
+
+    target.participants = [...target.participants, memberList[0]];
+    return HttpResponse.json({ status: 200 });
   }),
   http.delete('/mogaco/:id/join', ({ params: { id } }) => {
-    participantsList[Number(id) - 1] = participantsList[Number(id) - 1].filter(
-      (participant) => participant.providerId !== memberList[0].providerId,
+    const target = participantsList.find((item) => item.id === id);
+    if (!target) {
+      return HttpResponse.json({ status: 404 });
+    }
+
+    target.participants = target.participants.filter(
+      (item) => item.providerId !== memberList[0].providerId,
     );
-    return HttpResponse.json(null, { status: 200 });
+    return HttpResponse.json({ status: 200 });
   }),
 ];

--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
-import { Member, Mogaco } from '@/types';
+import { Member, Mogaco, MogacoPostRequest } from '@/types';
 
 import { memberList } from './members';
 
@@ -61,7 +61,15 @@ const participantsList: { id: string; participants: Member[] }[] = [
 
 export const mogacoAPIHandlers = [
   http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
-  http.post('/mogaco', () => HttpResponse.json({ status: 201 })),
+  http.post<never, MogacoPostRequest>('/mogaco', async ({ request }) => {
+    const body = await request.json();
+    mogacoList.push({
+      ...body,
+      id: String(mogacoList[mogacoList.length - 1].id + 1),
+      member: memberList[0],
+    });
+    return HttpResponse.json(null, { status: 201 });
+  }),
   http.get('/mogaco/:id', ({ params: { id } }) =>
     HttpResponse.json<Mogaco>(mogacoList.find((mogaco) => mogaco.id === id)),
   ),
@@ -77,11 +85,11 @@ export const mogacoAPIHandlers = [
   http.post('/mogaco/:id/join', ({ params: { id } }) => {
     const target = participantsList.find((item) => item.id === id);
     if (!target) {
-      return HttpResponse.json({ status: 404 });
+      return HttpResponse.json(null, { status: 404 });
     }
 
     target.participants = [...target.participants, memberList[0]];
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json(null, { status: 200 });
   }),
   http.delete('/mogaco/:id/join', ({ params: { id } }) => {
     const target = participantsList.find((item) => item.id === id);

--- a/app/frontend/src/pages/MogacoDetail/index.tsx
+++ b/app/frontend/src/pages/MogacoDetail/index.tsx
@@ -1,53 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-
 import { MogacoDetailPage } from '@/components';
-import { mogaco } from '@/services';
-import { Mogaco } from '@/types';
 
 export function MogacoDetail() {
-  const { id } = useParams();
-  const [mogacoData, setMogacoData] = useState<Mogaco | null>(null);
-
-  useEffect(() => {
-    if (!id || mogacoData) {
-      return;
-    }
-
-    const fetchMogacoData = async () => {
-      const data = await mogaco.detail(id);
-      setMogacoData(data);
-    };
-
-    fetchMogacoData();
-  }, [id, mogacoData]);
-
-  if (!mogacoData) {
-    return <div>불러오는 중...</div>;
-  }
-
-  const {
-    memberId,
-    groupId,
-    title,
-    maxHumanCount,
-    date,
-    address,
-    contents,
-    status,
-  } = mogacoData;
-
-  return (
-    <MogacoDetailPage
-      id={id as string}
-      memberId={memberId}
-      groupId={groupId}
-      title={title}
-      maxHumanCount={maxHumanCount}
-      date={date}
-      address={address}
-      contents={contents}
-      status={status}
-    />
-  );
+  return <MogacoDetailPage />;
 }

--- a/app/frontend/src/queries/hooks/mogaco.ts
+++ b/app/frontend/src/queries/hooks/mogaco.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { queryKeys } from '@/queries';
 import { mogaco } from '@/services';
-
-import { queryKeys } from '..';
 
 export const useDeleteMogacoQuery = () => {
   const queryClient = useQueryClient();
@@ -12,6 +11,32 @@ export const useDeleteMogacoQuery = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mogaco.list().queryKey,
+      });
+    },
+  });
+};
+
+export const useJoinMogacoQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: string) => mogaco.join(postId),
+    onSuccess: (data, postId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mogaco.participants(postId).queryKey,
+      });
+    },
+  });
+};
+
+export const useQuitMogacoQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: string) => mogaco.delete(postId),
+    onSuccess: (data, postId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mogaco.participants(postId).queryKey,
       });
     },
   });

--- a/app/frontend/src/queries/hooks/mogaco.ts
+++ b/app/frontend/src/queries/hooks/mogaco.ts
@@ -21,7 +21,7 @@ export const useJoinMogacoQuery = () => {
 
   return useMutation({
     mutationFn: (postId: string) => mogaco.join(postId),
-    onSuccess: (data, postId) => {
+    onSuccess: (_, postId) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mogaco.participants(postId).queryKey,
       });
@@ -34,7 +34,7 @@ export const useQuitMogacoQuery = () => {
 
   return useMutation({
     mutationFn: (postId: string) => mogaco.quit(postId),
-    onSuccess: (data, postId) => {
+    onSuccess: (_, postId) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mogaco.participants(postId).queryKey,
       });

--- a/app/frontend/src/queries/hooks/mogaco.ts
+++ b/app/frontend/src/queries/hooks/mogaco.ts
@@ -33,7 +33,7 @@ export const useQuitMogacoQuery = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (postId: string) => mogaco.delete(postId),
+    mutationFn: (postId: string) => mogaco.quit(postId),
     onSuccess: (data, postId) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.mogaco.participants(postId).queryKey,

--- a/app/frontend/src/queries/index.ts
+++ b/app/frontend/src/queries/index.ts
@@ -1,6 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+ 
 import { mergeQueryKeys } from '@lukemorales/query-key-factory';
 
+import { memberKeys } from './member';
 import { mogacoKeys } from './mogaco';
 
-export const queryKeys = mergeQueryKeys(mogacoKeys);
+export const queryKeys = mergeQueryKeys(mogacoKeys, memberKeys);

--- a/app/frontend/src/queries/member.ts
+++ b/app/frontend/src/queries/member.ts
@@ -1,0 +1,7 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+import { member } from '@/services';
+
+export const memberKeys = createQueryKeys('member', {
+  me: () => ({ queryKey: ['me'], queryFn: () => member.myInfo() }),
+});

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -1,4 +1,3 @@
- 
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 import { mogaco } from '@/services';
@@ -8,6 +7,12 @@ export const mogacoKeys = createQueryKeys('mogaco', {
     queryKey: [{ filters }],
     queryFn: () => mogaco.list(),
   }),
-  detail: (id: string) => [id],
-  participants: (id: string) => [id],
+  detail: (id: string) => ({
+    queryKey: [id],
+    queryFn: () => mogaco.detail(id),
+  }),
+  participants: (id: string) => ({
+    queryKey: [id],
+    queryFn: () => mogaco.participants(id),
+  }),
 });

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+ 
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 import { mogaco } from '@/services';
@@ -9,4 +9,5 @@ export const mogacoKeys = createQueryKeys('mogaco', {
     queryFn: () => mogaco.list(),
   }),
   detail: (id: string) => [id],
+  participants: (id: string) => [id],
 });

--- a/app/frontend/src/services/member.ts
+++ b/app/frontend/src/services/member.ts
@@ -1,4 +1,4 @@
-import { UserInfo } from '@/types';
+import { Member } from '@/types';
 
 import { morakAPI } from './morakAPI';
 
@@ -9,12 +9,12 @@ export const member = {
   },
 
   myInfo: async () => {
-    const { data } = await morakAPI.get<UserInfo>(member.endPoint.me);
+    const { data } = await morakAPI.get<Member>(member.endPoint.me);
     return data;
   },
 
-  userInfoById: async (id: string) => {
-    const { data } = await morakAPI.get<UserInfo>(
+  infoById: async (id: string) => {
+    const { data } = await morakAPI.get<Member>(
       `${member.endPoint.default}/${id}`,
     );
     return data;

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -1,4 +1,4 @@
-import { Member, Mogaco } from '@/types';
+import { Member, Mogaco, MogacoPostRequest } from '@/types';
 
 import { morakAPI } from './morakAPI';
 
@@ -19,6 +19,10 @@ export const mogaco = {
   },
   post: async (form: MogacoPostRequest) =>
     morakAPI.post(mogaco.endPoint.index, form),
+  delete: async (id: string) => {
+    const response = await morakAPI.delete(`${mogaco.endPoint.index}/${id}`);
+    return response;
+  },
   participants: async (id: string) => {
     const { data } = await morakAPI.get<Member[]>(
       `${mogaco.endPoint.index}/${id}/participants`,
@@ -33,10 +37,6 @@ export const mogaco = {
     const response = await morakAPI.delete(
       `${mogaco.endPoint.index}/${id}/join`,
     );
-    return response;
-  },
-  delete: async (id: string) => {
-    const response = await morakAPI.delete(`${mogaco.endPoint.index}/${id}`);
     return response;
   },
 };

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -26,10 +26,14 @@ export const mogaco = {
     return data;
   },
   join: async (id: string) => {
-    await morakAPI.post(`${mogaco.endPoint.index}/${id}/join`);
+    const response = await morakAPI.post(`${mogaco.endPoint.index}/${id}/join`);
+    return response;
   },
   quit: async (id: string) => {
-    await morakAPI.delete(`${mogaco.endPoint.index}/${id}/join`);
+    const response = await morakAPI.delete(
+      `${mogaco.endPoint.index}/${id}/join`,
+    );
+    return response;
   },
   delete: async (id: string) => {
     const response = await morakAPI.delete(`${mogaco.endPoint.index}/${id}`);

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -1,4 +1,4 @@
-import { Mogaco, Participant, MogacoPostRequest } from '@/types';
+import { Member, Mogaco } from '@/types';
 
 import { morakAPI } from './morakAPI';
 
@@ -20,7 +20,7 @@ export const mogaco = {
   post: async (form: MogacoPostRequest) =>
     morakAPI.post(mogaco.endPoint.index, form),
   participants: async (id: string) => {
-    const { data } = await morakAPI.get<Participant[]>(
+    const { data } = await morakAPI.get<Member[]>(
       `${mogaco.endPoint.index}/${id}/participants`,
     );
     return data;

--- a/app/frontend/src/stores/user.ts
+++ b/app/frontend/src/stores/user.ts
@@ -1,6 +1,6 @@
 import { atom, useAtom } from 'jotai';
 
-import { UserInfo } from '@/types';
+import { Member } from '@/types';
 
-const userStore = atom<UserInfo | null>(null);
+const userStore = atom<Member | null>(null);
 export const useUserAtom = () => useAtom(userStore);

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -1,3 +1,3 @@
 export * from './chatting';
+export * from './member';
 export * from './mogaco';
-export * from './user';

--- a/app/frontend/src/types/member.ts
+++ b/app/frontend/src/types/member.ts
@@ -1,4 +1,4 @@
-export type UserInfo = {
+export type Member = {
   providerId: string;
   email: string;
   nickname: string;

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -1,3 +1,5 @@
+import { Member } from './member';
+
 interface MogacoTypes {
   id: string;
   groupId: number;
@@ -23,7 +25,7 @@ export type Mogaco = Pick<
   | 'maxHumanCount'
   | 'address'
   | 'status'
->;
+> & { member: Member };
 
 export type MogacoPostForm = Pick<
   MogacoTypes,
@@ -46,9 +48,4 @@ export type MogacoPostRequest = Pick<
   | 'maxHumanCount'
   | 'address'
   | 'status'
->;
-
-export type Participant = Pick<
-  MogacoTypes,
-  'id' | 'nickname' | 'profilePicture'
 >;

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -18,7 +18,6 @@ export type Mogaco = Pick<
   MogacoTypes,
   | 'id'
   | 'groupId'
-  | 'memberId'
   | 'title'
   | 'contents'
   | 'date'


### PR DESCRIPTION
## 설명
- #154
- #155
- 모각코 상세 게시글 페이지에서 사용되는 기능에 대한 API를 작성하고 연동합니다.

## 완료한 기능 명세
- [ ] 모각코 주최자일 경우 - 수정 및 삭제
- [ ] 모각코 미참여자일 경우 - 참석하기
- [ ] 모각코 참여자일 경우 - 참석 취소

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

## 고민한 내용
- react-query를 사용하면 서버 상태를 마치 전역 상태처럼 어떤 컴포넌트에서든 자유롭게 불러올 수 있는데, 이 경우 서버 상태에 대하여 부모-자식 컴포넌트 간 props 전달이 굳이 필요할지, 필요하다면 그 중 어떤 값을 전달해야 할지 고민이 되었습니다.
  - 각자의 컴포넌트 안에서 `useQuery`로 불러오기: 성능에 대한 걱정도 있지만 중복 코드, 컴포넌트가 커지는 문제가 있음.
  - 최상위 컴포넌트에서 불러온 후 props로 내려주기: 기존 리액트식 상태 관리 문제처럼 props drilling이 발생함.
 
## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

