### PR TITLE
[Fix] 참석자 목록 overflow 값을 scroll에서 auto로 변경

### DIFF
--- a/app/frontend/src/components/MogacoDetail/index.css.ts
+++ b/app/frontend/src/components/MogacoDetail/index.css.ts
@@ -65,7 +65,7 @@ export const map = style({
 export const participants = style({
   display: 'none',
   gap: '0.8rem',
-  overflowX: 'scroll',
+  overflowX: 'auto',
 
   selectors: {
     [`${shown}&`]: {


### PR DESCRIPTION
## 설명
- 참석자 목록의 길이가 부모 요소를 넘지 않는 경우 스크롤바를 보이지 않도록 변경했습니다.

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/8e17b92f-620b-460b-9916-96e985b42e8d)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

