### PR TITLE
[Feat] 닉네임, 프로필 사진 링크 DB 추가 저장 및 반환

### DIFF
--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -14,6 +14,8 @@ model Member {
   id           BigInt     @id @default(autoincrement()) @db.BigInt
   providerId  String     @unique @db.VarChar(191) @map("provider_id")
   email        String    @unique @db.VarChar(191)
+  nickname     String    @db.VarChar(191)
+  profilePicture String  @db.VarChar(191) @map("profile_picture")
   socialType  String     @db.VarChar(191) @map("social_type")
   createdAt   DateTime   @default(now()) @map("created_at")
   users GroupToUser[]

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -19,6 +19,8 @@ export class AuthRepository {
         providerId: userDto.providerId,
         socialType: userDto.socialType,
         email: userDto.email,
+        nickname: userDto.nickname,
+        profilePicture: userDto.profilePicture,
       },
     });
   }

--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { MemberDto } from 'src/member/dto/member.dto';
+import { MemberInformationDto } from 'src/member/dto/member.dto';
 
 export class MogacoWithMemberDto {
   @ApiProperty({ description: 'ID of the Mogaco', example: '3' })
@@ -26,6 +26,6 @@ export class MogacoWithMemberDto {
   @ApiProperty({ description: 'Status of the Mogaco', example: '모집 마감' })
   status: string;
 
-  @ApiProperty({ description: 'Member information', type: MemberDto })
-  member: MemberDto;
+  @ApiProperty({ description: 'Member information', type: MemberInformationDto })
+  member: MemberInformationDto;
 }

--- a/app/backend/src/mogaco/dto/response-participants.dto.ts
+++ b/app/backend/src/mogaco/dto/response-participants.dto.ts
@@ -10,8 +10,11 @@ export class ParticipantResponseDto {
   @ApiProperty({ description: 'Email of the Member', example: 'bcwm.morak@gmail.com' })
   email: string;
 
-  @ApiProperty({ description: 'Social Type', example: 'google' })
-  socialType: string;
+  @ApiProperty({ description: 'Nickname of the user', example: 'morak morak' })
+  nickname: string;
+
+  @ApiProperty({ description: "URL of the user's profile picture", example: 'https://example.com/profile.jpg' })
+  profilePicture: string;
 
   @ApiProperty({ description: 'Date of Member creation', example: '2023-11-22T04:55:02.988Z' })
   createdAt: string;

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -37,10 +37,10 @@ export class MogacoRepository {
       address: mogaco.address,
       status: mogaco.status,
       member: {
-        id: mogaco.member.id,
         providerId: mogaco.member.providerId,
         email: mogaco.member.email,
-        socialType: mogaco.member.socialType,
+        nickname: mogaco.member.nickname,
+        profilePicture: mogaco.member.profilePicture,
       },
     };
   }


### PR DESCRIPTION
## 설명
- close #169 
- close #

현재 클라이언트에서 필요한 정보에 닉네임과 프로필 사진 링크가 포함되어있어서 DB 스키마에 해당 레코드를 추가하였습니다.
그리고 로그인 시 해당 정보들도 함께 저장하도로 구현하였으며, Swagger 설정을 하였습니다.

Member 테이블에 현재 로그인한 상태에 대한 DI가 심어져있기 때문에 유지보수성이 좋아 작업이 어렵진 않았습니다.

## 완료한 기능 명세
- [x] 닉네임, 프로필 사진 링크 DB 추가 저장 및 반환

### 스크린샷

### 글 작성
<img width="626" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/52f7df64-492b-469b-97f3-fd661e90fa03">


### 특정 게시물 조회
<img width="633" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/4fa3ee83-eb39-4c66-94ec-eebc80ae64bd">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

