### PR TITLE
[Fix] db 마이그레이션 로직 변경

### DIFF
--- a/app/backend/.gitignore
+++ b/app/backend/.gitignore
@@ -33,6 +33,3 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-
-# Prisma migrations
-/prisma/migrations

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -42,7 +42,6 @@ COPY --from=builder /app/packages /app/packages
 # 예: 환경변수 파일, 정적 파일 등
 
 # 애플리케이션 실행
-# CMD ["node", "dist/src/main.js"]
 COPY app/backend/wait-for-it.sh /wait-for-it.sh
 COPY app/backend/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /wait-for-it.sh

--- a/app/backend/prisma/migrations/20231124100030_init/migration.sql
+++ b/app/backend/prisma/migrations/20231124100030_init/migration.sql
@@ -1,0 +1,71 @@
+-- CreateTable
+CREATE TABLE `Member` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `provider_id` VARCHAR(191) NOT NULL,
+    `email` VARCHAR(191) NOT NULL,
+    `nickname` VARCHAR(191) NOT NULL,
+    `profile_picture` VARCHAR(191) NOT NULL,
+    `social_type` VARCHAR(191) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `Member_provider_id_key`(`provider_id`),
+    UNIQUE INDEX `Member_email_key`(`email`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Mogaco` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `group_id` BIGINT NOT NULL,
+    `member_id` BIGINT NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `contents` VARCHAR(191) NOT NULL,
+    `date` DATETIME NOT NULL,
+    `max_human_count` TINYINT NOT NULL DEFAULT 1,
+    `address` VARCHAR(191) NOT NULL,
+    `status` VARCHAR(191) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NULL,
+    `deleted_at` DATETIME NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Group` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `GroupToUser` (
+    `group_id` BIGINT NOT NULL,
+    `user_id` BIGINT NOT NULL,
+
+    PRIMARY KEY (`group_id`, `user_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Participant` (
+    `post_id` BIGINT NOT NULL,
+    `user_id` BIGINT NOT NULL,
+
+    PRIMARY KEY (`post_id`, `user_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Mogaco` ADD CONSTRAINT `Mogaco_member_id_fkey` FOREIGN KEY (`member_id`) REFERENCES `Member`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GroupToUser` ADD CONSTRAINT `GroupToUser_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `Group`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GroupToUser` ADD CONSTRAINT `GroupToUser_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `Member`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Participant` ADD CONSTRAINT `Participant_post_id_fkey` FOREIGN KEY (`post_id`) REFERENCES `Mogaco`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Participant` ADD CONSTRAINT `Participant_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `Member`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## 설명
- DB 마이그레이션 방법 변경
1. Prisma을 이용해서 DB 마이그레이션을 했을 때 기록을 VCS에서 관리해야 함.
2. 기존 Schema에서 변경 사항만 migrate 되도록 해야 함.

## 주의 사항
- 기존에 마이그레이션 했던 정보가 날아가지 않도록 주의 해야함.
- 기존에 마이그레이션 했던 정보를 지워야 하는 경우 소통 후 제거 합시다.

## 리뷰 요청 사항
@ldhbenecia 

