### PR TITLE
[Feat] DB 사용자 정보(닉네임, 프로필 사진 주소) 최신화 구현

### DIFF
--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -25,6 +25,20 @@ export class AuthRepository {
     });
   }
 
+  async updateUser(userDto: CreateUserDto): Promise<Member> {
+    const providerId = userDto.providerId;
+
+    return this.prisma.member.update({
+      where: {
+        providerId,
+      },
+      data: {
+        nickname: userDto.nickname,
+        profilePicture: userDto.profilePicture,
+      },
+    });
+  }
+
   async findUserByIdentifier(providerId: string): Promise<Member | null> {
     return this.prisma.member.findUnique({
       where: {

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -38,6 +38,15 @@ export class AuthService {
   }
 
   async signIn(userDto: CreateUserDto): Promise<Tokens | null> {
+    const providerId = userDto.providerId;
+    const existingUser = await this.authRepository.findUserByIdentifier(providerId);
+
+    if (existingUser) {
+      if (userDto.nickname !== existingUser.nickname || userDto.profilePicture !== existingUser.profilePicture) {
+        await this.authRepository.updateUser(userDto);
+      }
+    }
+
     const token = this.generateJwt({
       providerId: userDto.providerId,
       socialType: userDto.socialType,


### PR DESCRIPTION
## 설명
- close #177 

현재 첫 로그인을 할 때 사용자의 닉네임과 프로필 사진에 대한 정보를 알기 위해 DB에 기록하는 로직으로 변경하였습니다.
하지만 사용자는 구글에서 본인의 닉네임, 프로필 사진을 변경할 수 있습니다.

그에 대해 사용자가 로그인을 했을 때 DB에 기록되어있는 닉네임, 프로필 사진 주소가 같은 지 확인 후 다르다면 업데이트를 합니다.

## 완료한 기능 명세
- [x]  DB 사용자 정보 최신화 구현

### 스크린샷
[백로그 스크린샷 기록](https://ttaerrim.notion.site/375b2885383d435c9612208b67b0856f?pvs=4)


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

