### PR TITLE
[Feat] Group Swagger 문서화 작업

### DIFF
--- a/app/backend/libs/utils/swagger.ts
+++ b/app/backend/libs/utils/swagger.ts
@@ -5,8 +5,17 @@ export function setupSwagger(app: INestApplication): void {
   const config = new DocumentBuilder()
     .setTitle('Morak')
     .setDescription('Morak API description')
-    .setVersion('1.0')
+    .setVersion('1.0.0')
     .addTag('moraks')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'JWT',
+        in: 'header',
+      },
+      'access_token',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -10,15 +10,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import {
-  ApiBearerAuth,
-  ApiBody,
-  ApiCreatedResponse,
-  ApiOperation,
-  ApiResponse,
-  ApiSecurity,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBody, ApiCreatedResponse, ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { GoogleOauthGuard } from './guards/google-oauth.guard';
 import { Request, Response } from 'express';
 import { RtGuard } from './guards/rt.guard';
@@ -37,7 +29,6 @@ export class AuthController {
     summary: 'Google 로그인 요청 API',
     description: 'Google OAuth API에 로그인 요청',
   })
-  @ApiBearerAuth()
   @ApiResponse({ status: 200, description: 'Successful operation' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async googleLogin(): Promise<void> {}

--- a/app/backend/src/groups/dto/response-groups.dto.ts
+++ b/app/backend/src/groups/dto/response-groups.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResponseGroupsDto {
+  @ApiProperty({ description: 'ID of the Group', example: '1' })
+  id: string;
+
+  @ApiProperty({ description: 'title of the Group', example: '부스트캠프 웹・모바일 8기' })
+  title: string;
+}

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -3,28 +3,60 @@ import { GroupsService } from './groups.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { Group, Member } from '@prisma/client';
 import { AtGuard } from 'src/auth/guards/at.guard';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ParticipantResponseDto } from 'src/mogaco/dto/response-participants.dto';
+import { ResponseGroupsDto } from './dto/response-groups.dto';
 
+@ApiTags('Group API')
 @Controller('groups')
 @UseGuards(AtGuard)
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 
   @Get('/')
+  @ApiOperation({
+    summary: '모든 그룹 조회',
+    description: '존재하는 모든 그룹을 조회합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [ResponseGroupsDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllGroups(): Promise<Group[]> {
     return this.groupsService.getAllGroups();
   }
 
   @Get('/:id/groups')
+  @ApiOperation({
+    summary: '특정 그룹 소속 인원 조회',
+    description: '특정 그룹의 Id 값으로 해당 그룹의 소속 인원을 조회합니다.',
+  })
+  @ApiParam({ name: 'id', description: '조회할 그룹의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [ParticipantResponseDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllMembersOfGroup(@Param('id', ParseIntPipe) id: number): Promise<Member[]> {
     return this.groupsService.getAllMembersOfGroup(id);
   }
 
   @Post('/:id/join')
+  @ApiOperation({
+    summary: '그룹 참가',
+    description: '특정 그룹에 참가합니다.',
+  })
+  @ApiParam({ name: 'id', description: '참가할 그룹의 Id' })
+  @ApiResponse({ status: 201, description: 'Successfully join' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async joinGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.joinGroup(id, member);
   }
 
   @Delete('/:id/leave')
+  @ApiOperation({
+    summary: '그룹 참가 취소',
+    description: '특정 그룹 참가를 취소합니다.',
+  })
+  @ApiParam({ name: 'id', description: '참가를 취소할 그룹의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully leaved join' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);
   }

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -3,13 +3,14 @@ import { GroupsService } from './groups.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { Group, Member } from '@prisma/client';
 import { AtGuard } from 'src/auth/guards/at.guard';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ParticipantResponseDto } from 'src/mogaco/dto/response-participants.dto';
 import { ResponseGroupsDto } from './dto/response-groups.dto';
 
 @ApiTags('Group API')
 @Controller('groups')
 @UseGuards(AtGuard)
+@ApiBearerAuth('access_token')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 

--- a/app/backend/src/member/member.controller.ts
+++ b/app/backend/src/member/member.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Req, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { MemberInformationDto } from './dto/member.dto';
 import { AtGuard } from 'src/auth/guards/at.guard';
@@ -8,6 +8,7 @@ import { AtGuard } from 'src/auth/guards/at.guard';
 @ApiTags('Member Infomation API')
 @Controller('member')
 @UseGuards(AtGuard)
+@ApiBearerAuth('access_token')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 

--- a/app/backend/src/mogaco/dto/response-participants.dto.ts
+++ b/app/backend/src/mogaco/dto/response-participants.dto.ts
@@ -16,6 +16,9 @@ export class ParticipantResponseDto {
   @ApiProperty({ description: "URL of the user's profile picture", example: 'https://example.com/profile.jpg' })
   profilePicture: string;
 
+  @ApiProperty({ description: 'Social Login Type', example: 'google' })
+  socialType: string;
+
   @ApiProperty({ description: 'Date of Member creation', example: '2023-11-22T04:55:02.988Z' })
   createdAt: string;
 }

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -6,13 +6,14 @@ import { MogacoStatusValidationPipe } from './pipes/mogaco-status-validation.pip
 import { MogacoStatus } from './dto/mogaco-status.enum';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
-import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
 
 @ApiTags('Mogaco API')
 @Controller('mogaco')
 @UseGuards(AtGuard)
+@ApiBearerAuth('access_token')
 export class MogacoController {
   constructor(private readonly mogacoService: MogacoService) {}
 


### PR DESCRIPTION
## 설명
- close #144 

Api Test를 위해 액세스 토큰을 입력해서 로그인 상태를 만들고 해당 Api를 테스트 하도록 합니다.

## 완료한 기능 명세
- [x] Group Swagger 문서화 작업
- [x] Api Test를 위한 @ApiBearerAuth 설정

### 스크린샷
<img width="1387" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/6f6ff887-a263-457a-a1f4-44ee1b13c135">


<img width="1368" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/946d443b-c536-490a-af2c-0b86b1c44117">

<img width="1362" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/b4afffe7-73b2-4d73-b52e-b62b1e9ab274">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

