### PR TITLE
[Refactor] App.tsx와 main.tsx 용도 분리 및 리팩토링

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,12 +1,29 @@
+import { CookiesProvider } from 'react-cookie';
 import { RouterProvider } from 'react-router-dom';
 
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { useSetUserInfo, useRouter } from '@/hooks';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1 },
+  },
+});
 
 function App() {
   const router = useRouter();
   useSetUserInfo();
 
-  return <RouterProvider router={router} />;
+  return (
+    <CookiesProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </CookiesProvider>
+  );
 }
 
 export default App;

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { useSetUserInfo, useRouter } from '@/hooks';
 
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { retry: 1 },
+    queries: { retry: false },
   },
 });
 

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -1,41 +1,15 @@
 import React from 'react';
-import { CookiesProvider } from 'react-cookie';
 
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import ReactDOM from 'react-dom/client';
 
+import { enableMocking } from '@/utils';
+
 import App from './App';
-import { queryKeys } from './queries';
-
-async function enableMocking() {
-  if (import.meta.env.MODE !== 'development') {
-    return undefined;
-  }
-
-  const { worker } = await import('./mocks/browser');
-
-  return worker.start();
-}
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: 1 },
-  },
-});
-queryClient.setQueryDefaults(queryKeys.member.me().queryKey, {
-  staleTime: Infinity,
-});
 
 enableMocking().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <CookiesProvider>
-        <QueryClientProvider client={queryClient}>
-          <App />
-          <ReactQueryDevtools initialIsOpen={false} />
-        </QueryClientProvider>
-      </CookiesProvider>
+      <App />
     </React.StrictMode>,
   );
 });

--- a/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
@@ -5,6 +5,7 @@ import { useQueries } from '@tanstack/react-query';
 import { Button, Error, LoadingIndicator } from '@/components';
 import { queryKeys } from '@/queries';
 import {
+  getMyInfoQuery,
   useDeleteMogacoQuery,
   useJoinMogacoQuery,
   useQuitMogacoQuery,
@@ -23,7 +24,7 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
     { data: participantList, isLoading: participantListLoading },
   ] = useQueries({
     queries: [
-      queryKeys.member.me(),
+      getMyInfoQuery,
       queryKeys.mogaco.detail(id),
       queryKeys.mogaco.participants(id),
     ],

--- a/app/frontend/src/queries/hooks/index.ts
+++ b/app/frontend/src/queries/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './member';
 export * from './mogaco';

--- a/app/frontend/src/queries/hooks/member.ts
+++ b/app/frontend/src/queries/hooks/member.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { member } from '@/services';
+
+const memberKeys = {
+  me: ['me'],
+};
+
+export const getMyInfoQuery = {
+  queryKey: memberKeys.me,
+  queryFn: () => member.myInfo(),
+  staleTime: Infinity,
+};
+
+export { memberKeys };
+export const useGetMyInfoQuery = () => useQuery(getMyInfoQuery);

--- a/app/frontend/src/queries/index.ts
+++ b/app/frontend/src/queries/index.ts
@@ -1,7 +1,5 @@
- 
 import { mergeQueryKeys } from '@lukemorales/query-key-factory';
 
-import { memberKeys } from './member';
 import { mogacoKeys } from './mogaco';
 
-export const queryKeys = mergeQueryKeys(mogacoKeys, memberKeys);
+export const queryKeys = mergeQueryKeys(mogacoKeys);

--- a/app/frontend/src/queries/member.ts
+++ b/app/frontend/src/queries/member.ts
@@ -1,7 +1,0 @@
-import { createQueryKeys } from '@lukemorales/query-key-factory';
-
-import { member } from '@/services';
-
-export const memberKeys = createQueryKeys('member', {
-  me: () => ({ queryKey: ['me'], queryFn: () => member.myInfo() }),
-});

--- a/app/frontend/src/utils/index.ts
+++ b/app/frontend/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './cookies';
+export * from './mocking';

--- a/app/frontend/src/utils/mocking.ts
+++ b/app/frontend/src/utils/mocking.ts
@@ -1,0 +1,9 @@
+export async function enableMocking() {
+  if (import.meta.env.MODE !== 'development') {
+    return undefined;
+  }
+
+  const { worker } = await import('../mocks/browser');
+
+  return worker.start();
+}


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #189 
- query-key-factory에서 staleTime 옵션을 지정할 수 없어 /member/me에 대한 커스텀 훅을 따로 분리하였습니다.
- React-Query의 retry 기본 값을 false로 변경했습니다. → 더 빠른 UI 반영을 위함


## 완료한 기능 명세
- [x] 모킹 활성화 함수 분리
- [x] App.tsx와 main.tsx 용도 나누고 코드 정리
- [x] member.me에 대한 staleTime 정의하는 부분을 커스텀 훅으로 분리   

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

