### PR TITLE
[Feat] local에서 API test를 위한 command 추가

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:test": "vite --mode test",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0 --fix",

--- a/app/frontend/src/constants/url.ts
+++ b/app/frontend/src/constants/url.ts
@@ -1,3 +1,6 @@
 export const URL = {
-  API: 'http://soma2.iptime.org:9991',
+  API:
+    import.meta.env.MODE === 'test'
+      ? 'http://localhost:8080'
+      : 'http://soma2.iptime.org:9991',
 };

--- a/app/frontend/src/services/morakAPI.ts
+++ b/app/frontend/src/services/morakAPI.ts
@@ -12,6 +12,6 @@ const headers = getCookies('access_token')
   : initialHeaders;
 
 export const morakAPI = axios.create({
-  baseURL: import.meta.env.DEV ? '' : URL.API,
+  baseURL: import.meta.env.MODE === 'development' ? '' : URL.API,
   headers,
 });


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- Iocal 환경에서 API를 localhost:8080로 테스트하기 위한 command를 추가했습니다.
- [Vite Env Mode](https://vitejs.dev/guide/env-and-mode.html#env-variables-and-modes)를 참고했습니다.
  - `--mode test` 옵션을 붙여 실행할 경우 `import.meta.env.MODE`를 통해 test라는 문자열에 접근할 수 있어 이를 사용

## 완료한 기능 명세
- [x] local 환경에서 API 테스트 위한 커맨드 추가

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

