### PR TITLE
[Bug] MogacoSidebar의 아이콘 width와 height 설정

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/InfoWrapper.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/InfoWrapper.tsx
@@ -10,17 +10,17 @@ export function InfoWrapper() {
   return (
     <div className={styles.infoWrapper}>
       <div className={styles.infoContent}>
-        <People className={styles.icon} />
+        <People className={styles.icon} width={16} height={16} />
         <div className={styles.infoText}>2/5</div>
       </div>
       <div className={styles.infoContent}>
-        <Map className={styles.icon} />
+        <Map className={styles.icon} width={16} height={16} />
         <div className={styles.infoText}>
           서울 관악구 남현3길 71 크레이저 커피
         </div>
       </div>
       <div className={styles.infoContent}>
-        <Calendar className={styles.icon} />
+        <Calendar className={styles.icon} width={16} height={16} />
         <div className={styles.infoText}>
           {dayjs('2023-11-7').format('YYYY/MM/DD HH:mm~')}
         </div>


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #197 
- 아이콘 크기 조절 추가

## 완료한 기능 명세
- [x] MogacoSidebar 컴포넌트의 아이콘 크기를 설정하지 않아 왕 크게 나오는 버그 수정 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

before

<img width="1440" alt="스크린샷 2023-11-27 15 53 33" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/66de2545-8c54-4375-98d2-2da340ee240e">

after

![스크린샷 2023-11-27 15 29 09](https://github.com/boostcampwm2023/web17_morak/assets/43867711/cfbd0fac-b967-4523-be6f-837d2357e109)
## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기


