### PR TITLE
[Feat] /auth/refresh API 보수 및 Swagger

### DIFF
--- a/app/backend/libs/utils/swagger.ts
+++ b/app/backend/libs/utils/swagger.ts
@@ -7,6 +7,7 @@ export function setupSwagger(app: INestApplication): void {
     .setDescription('Morak API description')
     .setVersion('1.0.0')
     .addTag('moraks')
+    .addCookieAuth('refresh_token')
     .addBearerAuth(
       {
         type: 'http',

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -10,20 +10,28 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { ApiBody, ApiCreatedResponse, ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
 import { GoogleOauthGuard } from './guards/google-oauth.guard';
 import { Request, Response } from 'express';
 import { LogoutDto } from './dto/user.dto';
 import { getSecret } from 'vault';
 
 @ApiTags('Oauth API')
-@ApiSecurity('google')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Get('/google/login')
   @UseGuards(GoogleOauthGuard)
+  @ApiSecurity('google')
   @ApiOperation({
     summary: 'Google 로그인 요청 API',
     description: 'Google OAuth API에 로그인 요청',
@@ -34,6 +42,7 @@ export class AuthController {
 
   @Get('/google/callback')
   @UseGuards(GoogleOauthGuard)
+  @ApiSecurity('google')
   @ApiOperation({
     summary: 'Google OAuth 콜백 처리',
     description: '로그인을 진행하여 Access, Refresh Token 발급',
@@ -85,6 +94,7 @@ export class AuthController {
   }
 
   @Post('/refresh')
+  @ApiCookieAuth()
   @ApiOperation({
     summary: 'Refresh Token을 이용하여 Access Token 재갱신',
     description: 'cookie에 있는 Refresh Token을 이용해서 새로운 Access Token을 반환',

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -13,7 +13,6 @@ import { AuthService } from './auth.service';
 import { ApiBody, ApiCreatedResponse, ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { GoogleOauthGuard } from './guards/google-oauth.guard';
 import { Request, Response } from 'express';
-import { RtGuard } from './guards/rt.guard';
 import { LogoutDto } from './dto/user.dto';
 import { getSecret } from 'vault';
 
@@ -86,7 +85,6 @@ export class AuthController {
   }
 
   @Post('/refresh')
-  @UseGuards(RtGuard)
   @ApiOperation({
     summary: 'Refresh Token을 이용하여 Access Token 재갱신',
     description: 'cookie에 있는 Refresh Token을 이용해서 새로운 Access Token을 반환',

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -55,4 +55,8 @@ export class AuthRepository {
   async removeRefreshToken(providerId: string): Promise<void> {
     await this.cacheManager.del(providerId);
   }
+
+  async getRefreshToken(providerId: string): Promise<string | null> {
+    return this.cacheManager.get(providerId);
+  }
 }

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -68,6 +68,12 @@ export class AuthService {
       const decodedRefreshToken = this.jwtService.verify(refreshToken, { secret: getSecret('JWT_REFRESH_SECRET') });
       const { providerId, socialType } = decodedRefreshToken;
 
+      const storedRefreshToken = await this.authRepository.getRefreshToken(providerId);
+
+      if (storedRefreshToken !== refreshToken) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
       const token = this.generateJwt({ providerId: providerId, socialType: socialType });
 
       return token.access_token;

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -66,7 +66,7 @@ export class AuthService {
   async refresh(refreshToken: string): Promise<string> {
     try {
       const decodedRefreshToken = this.jwtService.verify(refreshToken, { secret: getSecret('JWT_REFRESH_SECRET') });
-      const { providerId, socialType } = decodedRefreshToken;
+      const { providerId, socialType, email, profilePicture, nickname } = decodedRefreshToken;
 
       const storedRefreshToken = await this.authRepository.getRefreshToken(providerId);
 
@@ -74,7 +74,13 @@ export class AuthService {
         throw new UnauthorizedException('Invalid refresh token');
       }
 
-      const token = this.generateJwt({ providerId: providerId, socialType: socialType });
+      const token = this.generateJwt({
+        providerId: providerId,
+        socialType: socialType,
+        email: email,
+        profilePicture: profilePicture,
+        nickname: nickname,
+      });
 
       return token.access_token;
     } catch (error) {


### PR DESCRIPTION
## 설명
- close #188 

본래 /auth/refersh 토큰 요청 상태가 바르지 않아 오류가 발생하였던 현상을 해결합니다.
/auth/refresh API 요청을 보내는 경우 해당 사용자의 상태는 refresh_token만 존재하고 access_token은 없는 경우일 수도 있으며, 
새 액세스 토큰을 발급받아야하는 상황이기에 bearer_token은 받지않고 해당 사용자의 쿠키에 있는 refresh_token을 서버에서 추출하여
Redis에 기록되어있는 값과 비교하는 검증 절차를 걸친 후 올바른 refresh_token일 경우, 새 액세스 토큰을 발급합니다.

Swagger에서 테스트를 진행하기 위해 @ApiCookieAuth()를 추가하여서 쿠키를 넣는 칸을 추가하였습니다.

## 완료한 기능 명세
- [x] /auth/refresh Test를 위한 Swagger 추가
- [x] refresh_token 검증

### 스크린샷
[백로그 스크린샷 기록](https://ttaerrim.notion.site/auth-refresh-f4195ecdf4c54f88a8aa173d3cc097cb?pvs=4)


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

