### PR TITLE
[Feat] 특정 모각코 조회 시 참가자 목록 반환

### DIFF
--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -1,6 +1,8 @@
 import { ResponseMogacoDto, ResponseMogacoWithMemberDto } from '@morak/apitype/dto/response/mogaco';
 import { ApiProperty } from '@nestjs/swagger';
 import { MemberInformationDto } from 'src/member/dto/member.dto';
+import { ParticipantResponseDto } from './response-participants.dto';
+import { ResponseParticipant } from '@morak/apitype/dto/response/participant';
 
 export class MogacoDto implements ResponseMogacoDto {
   @ApiProperty({ description: 'ID of the Mogaco', example: 1 })
@@ -55,4 +57,7 @@ export class MogacoWithMemberDto implements ResponseMogacoWithMemberDto {
 
   @ApiProperty({ description: 'Member information', type: MemberInformationDto })
   member: MemberInformationDto;
+
+  @ApiProperty({ description: 'Participants information', type: ParticipantResponseDto })
+  participants: ResponseParticipant[];
 }

--- a/app/backend/src/mogaco/dto/response-participants.dto.ts
+++ b/app/backend/src/mogaco/dto/response-participants.dto.ts
@@ -21,5 +21,5 @@ export class ParticipantResponseDto implements ResponseParticipant {
   socialType: string;
 
   @ApiProperty({ description: 'Date of Member creation', example: '2023-11-22T04:55:02.988Z' })
-  createdAt: string;
+  createdAt: Date;
 }

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -27,6 +27,8 @@ export class MogacoRepository {
       throw new NotFoundException(`Mogaco with id ${id} not found`);
     }
 
+    const participants = await this.getParticipants(id);
+
     return {
       id: mogaco.id,
       groupId: mogaco.groupId,
@@ -42,6 +44,7 @@ export class MogacoRepository {
         nickname: mogaco.member.nickname,
         profilePicture: mogaco.member.profilePicture,
       },
+      participants,
     };
   }
 

--- a/packages/apitype/dto/response/mogaco.ts
+++ b/packages/apitype/dto/response/mogaco.ts
@@ -1,4 +1,5 @@
 import { ResponseMemberDto } from "./member";
+import { ResponseParticipant } from "./participant";
 
 export interface ResponseMogacoDto {
   id: bigint;
@@ -11,17 +12,7 @@ export interface ResponseMogacoDto {
   status: string;
 }
 
-export interface ResponseMogacoWithMemberDto {
-  id: bigint;
-  groupId: bigint;
-  title: string;
-  contents: string;
-  date: Date;
-  maxHumanCount: number;
-  address: string;
-  status: string;
-}
-
 export interface ResponseMogacoWithMemberDto extends ResponseMogacoDto {
   member: ResponseMemberDto;
+  participants: ResponseParticipant[];
 }

--- a/packages/apitype/dto/response/participant.ts
+++ b/packages/apitype/dto/response/participant.ts
@@ -5,5 +5,5 @@ export interface ResponseParticipant {
   nickname: string;
   profilePicture: string;
   socialType: string;
-  createdAt: string;
+  createdAt: Date;
 }


### PR DESCRIPTION
## 설명
- close #202 

현재 프론트엔드단에서 API를 두번 씩 호출하는 상황이 생겼습니다.
@ttaerrim 님께서 설명해주시고 API 커넥션이 여러 번 일어나는 것은 좋지 않다고 판단되어
단 한번의 API 커넥션으로 필요한 정보를 전부 전달할 수 있도록 변경하였습니다.

## 완료한 기능 명세
- [x] 특정 모각코 조회 시 참가자 목록 반환
- [x] 중복 Dto 정리
- [x] Response 값이 변화함에 따른 Dto 파일 수정 

### 스크린샷
<img width="790" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/60e49562-9204-415d-8eb1-9a7d608d82d1">


<img width="824" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/00e37f4c-e7a2-401b-b1b4-f3b0d4ae51d4">


## 리뷰 요청 사항
추가적으로 필요한 사항 있으면 언제든지 말씀해주시면 감사하겠습니다.

