### PR TITLE
[Feat] 모각코 정보 반환 시 그룹명 추가 반환

### DIFF
--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -5,10 +5,10 @@ import { ParticipantResponseDto } from './response-participants.dto';
 import { ResponseParticipant } from '@morak/apitype/dto/response/participant';
 
 export class MogacoDto implements ResponseMogacoDto {
-  @ApiProperty({ description: 'ID of the Mogaco', example: 1 })
+  @ApiProperty({ description: 'ID of the Mogaco', example: '1' })
   id: bigint;
 
-  @ApiProperty({ description: 'Group ID', example: 1 })
+  @ApiProperty({ description: 'Group ID', example: '1' })
   groupId: bigint;
 
   @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
@@ -31,11 +31,14 @@ export class MogacoDto implements ResponseMogacoDto {
 }
 
 export class MogacoWithMemberDto implements ResponseMogacoWithMemberDto {
-  @ApiProperty({ description: 'ID of the Mogaco', example: '3' })
+  @ApiProperty({ description: 'ID of the Mogaco', example: '1' })
   id: bigint;
 
   @ApiProperty({ description: 'Group ID', example: '1' })
   groupId: bigint;
+
+  @ApiProperty({ description: 'Group Title', example: '부스트캠프 웹' })
+  groupTitle: string;
 
   @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
   title: string;

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -12,6 +12,9 @@ export class MogacoRepository {
   async getAllMogaco(): Promise<Mogaco[]> {
     return this.prisma.mogaco.findMany({
       where: { deletedAt: null },
+      include: {
+        group: true,
+      },
     });
   }
 
@@ -20,6 +23,7 @@ export class MogacoRepository {
       where: { id, deletedAt: null },
       include: {
         member: true,
+        group: true,
       },
     });
 
@@ -32,6 +36,7 @@ export class MogacoRepository {
     return {
       id: mogaco.id,
       groupId: mogaco.groupId,
+      groupTitle: mogaco.group.title,
       title: mogaco.title,
       contents: mogaco.contents,
       date: mogaco.date,

--- a/packages/apitype/dto/response/mogaco.ts
+++ b/packages/apitype/dto/response/mogaco.ts
@@ -13,6 +13,7 @@ export interface ResponseMogacoDto {
 }
 
 export interface ResponseMogacoWithMemberDto extends ResponseMogacoDto {
+  groupTitle: string;
   member: ResponseMemberDto;
   participants: ResponseParticipant[];
 }


### PR DESCRIPTION
## 설명
모각코 정보 반환할 때 그룹명도 반환해달라는 요청에 따른 구현

## 완료한 기능 명세
- [x] 모각코 정보 반환 시 그룹명 추가 반환

### 스크린샷
<img width="786" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/134d77ee-4bdd-41ce-88ba-1dabc3c38742">

<img width="800" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/8394955f-b6b8-424e-95d2-d56d411a15f3">



## 리뷰 요청 사항
x

