### PR TITLE
[Fix] 참여자 목록 정보 API 변경사항 반영

### DIFF
--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -1,14 +1,14 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 
-import { Member, Mogaco, MogacoPostRequest } from '@/types';
+import { Mogaco, MogacoPostRequest } from '@/types';
 
 import { memberList } from './members';
 
 let mogacoList: Mogaco[] = [
   {
     id: '1',
-    groupId: 1,
+    groupId: '1',
     title: '인천역 모각코',
     contents: '인천에서 같이 모각코 하실 분을 모십니다.',
     date: '2023-11-22T12:00:00.000Z',
@@ -16,10 +16,12 @@ let mogacoList: Mogaco[] = [
     address: '서울 관악구 어디길 어디로 뭐시기카페',
     status: '모집 중' as const,
     member: memberList[0],
+    participants: [memberList[0], memberList[1], memberList[2]],
+    group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
   },
   {
     id: '2',
-    groupId: 1,
+    groupId: '1',
     title: '이수역 모각코',
     contents: '이수역 모각코 하실 분 구합니다!',
     date: '2023-11-22T12:00:00.000Z',
@@ -27,10 +29,12 @@ let mogacoList: Mogaco[] = [
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
     member: memberList[2],
+    participants: [memberList[0], memberList[2]],
+    group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
   },
   {
     id: '3',
-    groupId: 1,
+    groupId: '1',
     title: '종각역 모각코',
     contents: '종각역에서 모각코 하실 분 구해요',
     date: '2023-10-11T12:00:00.000Z',
@@ -38,10 +42,12 @@ let mogacoList: Mogaco[] = [
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
     member: memberList[2],
+    participants: [memberList[1], memberList[2]],
+    group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
   },
   {
     id: '4',
-    groupId: 1,
+    groupId: '1',
     title: '사당역 모각코',
     contents: '사당역 크레이저 커피로 오세요~',
     date: '2023-11-22T12:00:00.000Z',
@@ -49,14 +55,9 @@ let mogacoList: Mogaco[] = [
     address: '주소주소주소주소주소',
     status: '모집 중' as const,
     member: memberList[1],
+    participants: [memberList[0], memberList[1]],
+    group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
   },
-];
-
-let participantsList: { id: string; participants: Member[] }[] = [
-  { id: '1', participants: [memberList[0], memberList[1], memberList[2]] },
-  { id: '2', participants: [memberList[0], memberList[2]] },
-  { id: '3', participants: [memberList[1], memberList[2]] },
-  { id: '4', participants: [memberList[0], memberList[1]] },
 ];
 
 export const mogacoAPIHandlers = [
@@ -68,12 +69,10 @@ export const mogacoAPIHandlers = [
       ...body,
       id: postId,
       member: memberList[0],
+      participants: [memberList[0]],
+      group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
     };
     mogacoList.push(newPost);
-    participantsList.push({
-      id: postId,
-      participants: [memberList[0]],
-    });
     return HttpResponse.json(newPost, { status: 201 });
   }),
   http.patch<{ id: string }, MogacoPostRequest>(
@@ -84,6 +83,8 @@ export const mogacoAPIHandlers = [
         ...body,
         id,
         member: memberList[0],
+        participants: [memberList[0]],
+        group: { id: '1', title: '부스트캠프 웹·모바일 8기' },
       };
       const targetIndex = mogacoList.findIndex((mogaco) => mogaco.id === id);
 
@@ -100,18 +101,10 @@ export const mogacoAPIHandlers = [
   ),
   http.delete('/mogaco/:id', ({ params: { id } }) => {
     mogacoList = mogacoList.filter((mogaco) => mogaco.id !== id);
-    participantsList = participantsList.filter(
-      (participants) => participants.id !== id,
-    );
     return HttpResponse.json({ status: 204 });
   }),
-  http.get('/mogaco/:id/participants', ({ params: { id } }) =>
-    HttpResponse.json<Member[]>(
-      participantsList.find((item) => item.id === id)?.participants,
-    ),
-  ),
   http.post('/mogaco/:id/join', ({ params: { id } }) => {
-    const target = participantsList.find((item) => item.id === id);
+    const target = mogacoList.find((item) => item.id === id);
     if (!target) {
       return HttpResponse.json(null, { status: 404 });
     }
@@ -120,7 +113,7 @@ export const mogacoAPIHandlers = [
     return HttpResponse.json(null, { status: 200 });
   }),
   http.delete('/mogaco/:id/join', ({ params: { id } }) => {
-    const target = participantsList.find((item) => item.id === id);
+    const target = mogacoList.find((item) => item.id === id);
     if (!target) {
       return HttpResponse.json({ status: 404 });
     }

--- a/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
@@ -21,13 +21,8 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
   const [
     { data: currentUser, isLoading: currentUserLoading },
     { data: mogacoData, isLoading: mogacoDataLoading },
-    { data: participantList, isLoading: participantListLoading },
   ] = useQueries({
-    queries: [
-      getMyInfoQuery,
-      queryKeys.mogaco.detail(id),
-      queryKeys.mogaco.participants(id),
-    ],
+    queries: [getMyInfoQuery, queryKeys.mogaco.detail(id)],
   });
 
   const deleteMogaco = useDeleteMogacoQuery();
@@ -61,7 +56,7 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
     await quitMogaco.mutateAsync(id);
   };
 
-  if (currentUserLoading || mogacoDataLoading || participantListLoading) {
+  if (currentUserLoading || mogacoDataLoading) {
     return (
       <Button theme="primary" shape="fill" size="large" disabled>
         <LoadingIndicator size={20} />
@@ -77,16 +72,14 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
     );
   }
 
-  if (!mogacoData || participantList === undefined) {
+  if (!mogacoData) {
     return <Error message="정보 불러오기 오류" />;
   }
 
   const userHosted = mogacoData.member.providerId === currentUser.providerId;
-  const userParticipated = participantList
-    ? participantList.find(
-        (participant) => participant.providerId === currentUser.providerId,
-      )
-    : false;
+  const userParticipated = !!mogacoData.participants.find(
+    (participant) => participant.providerId === currentUser.providerId,
+  );
 
   if (userHosted) {
     return (
@@ -121,7 +114,7 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
 
   if (
     mogacoData.status === '모집 중' &&
-    participantList.length < mogacoData.maxHumanCount
+    mogacoData.participants.length < mogacoData.maxHumanCount
   )
     return (
       <Button theme="primary" shape="fill" size="large" onClick={onClickJoin}>

--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useQueries } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
 import { ReactComponent as ArrowDown } from '@/assets/icons/arrow_down.svg';
@@ -21,22 +21,19 @@ type DetailInfoProps = {
 export function DetailInfo({ id }: DetailInfoProps) {
   const [participantsShown, setParticipantsShown] = useState(false);
 
-  const [
-    { data: mogacoData, isLoading: mogacoDataLoading },
-    { data: participantList, isLoading: participantListLoading },
-  ] = useQueries({
-    queries: [queryKeys.mogaco.detail(id), queryKeys.mogaco.participants(id)],
-  });
+  const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery(
+    queryKeys.mogaco.detail(id),
+  );
 
   const toggleParticipantsShown = () =>
     setParticipantsShown(!participantsShown);
 
-  if (participantListLoading || mogacoDataLoading) {
+  if (mogacoDataLoading) {
     return <Loading />;
   }
 
-  if (!mogacoData || !participantList) {
-    return <Error message="일부 정보를 불러오지 못했습니다." />;
+  if (!mogacoData) {
+    return <Error message="모각코 정보를 불러오지 못했습니다." />;
   }
 
   return (
@@ -44,7 +41,7 @@ export function DetailInfo({ id }: DetailInfoProps) {
       <div className={styles.infoItem}>
         <People width={24} height={24} fill={vars.color.grayscale200} />
         <span>
-          <span>{participantList.length}</span>/
+          <span>{mogacoData.participants.length}</span>/
           <span>{mogacoData.maxHumanCount}</span>
         </span>
         <button
@@ -62,7 +59,7 @@ export function DetailInfo({ id }: DetailInfoProps) {
           participantsShown ? styles.shown : ''
         }`}
       >
-        {participantList.map((participant) => (
+        {mogacoData.participants.map((participant) => (
           <UserChip
             key={participant.providerId}
             username={participant.nickname}

--- a/app/frontend/src/queries/hooks/mogaco.ts
+++ b/app/frontend/src/queries/hooks/mogaco.ts
@@ -23,7 +23,7 @@ export const useJoinMogacoQuery = () => {
     mutationFn: (postId: string) => mogaco.join(postId),
     onSuccess: (_, postId) => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.mogaco.participants(postId).queryKey,
+        queryKey: queryKeys.mogaco.detail(postId).queryKey,
       });
     },
   });
@@ -36,7 +36,7 @@ export const useQuitMogacoQuery = () => {
     mutationFn: (postId: string) => mogaco.quit(postId),
     onSuccess: (_, postId) => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.mogaco.participants(postId).queryKey,
+        queryKey: queryKeys.mogaco.detail(postId).queryKey,
       });
     },
   });

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -11,8 +11,4 @@ export const mogacoKeys = createQueryKeys('mogaco', {
     queryKey: [id],
     queryFn: () => mogaco.detail(id),
   }),
-  participants: (id: string) => ({
-    queryKey: [id],
-    queryFn: () => mogaco.participants(id),
-  }),
 });

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -1,4 +1,4 @@
-import { Member, Mogaco, MogacoPostRequest } from '@/types';
+import { Mogaco, MogacoPostRequest } from '@/types';
 
 import { morakAPI } from './morakAPI';
 
@@ -24,12 +24,6 @@ export const mogaco = {
   delete: async (id: string) => {
     const response = await morakAPI.delete(`${mogaco.endPoint.index}/${id}`);
     return response;
-  },
-  participants: async (id: string) => {
-    const { data } = await morakAPI.get<Member[]>(
-      `${mogaco.endPoint.index}/${id}/participants`,
-    );
-    return data;
   },
   join: async (id: string) => {
     const response = await morakAPI.post(`${mogaco.endPoint.index}/${id}/join`);

--- a/app/frontend/src/types/mogaco.ts
+++ b/app/frontend/src/types/mogaco.ts
@@ -2,7 +2,7 @@ import { Member } from './member';
 
 interface MogacoTypes {
   id: string;
-  groupId: number;
+  groupId: string;
   memberId: string;
   title: string;
   contents: string;
@@ -24,7 +24,11 @@ export type Mogaco = Pick<
   | 'maxHumanCount'
   | 'address'
   | 'status'
-> & { member: Member };
+> & {
+  member: Member;
+  participants: Member[];
+  group: { id: string; title: string };
+};
 
 export type MogacoPostForm = Pick<
   MogacoTypes,


### PR DESCRIPTION
## 설명
- 기존 `/mogaco/:id/participants` API가 `/mogaco/:id` API에 흡수되면서 생긴 변경사항들을 FE 코드에 반영하였습니다.
- 이제 모각코 참여자 목록에 대한 정보는 해당 모각코 게시글을 불러오는 한 번의 요청으로 처리 가능합니다.
- 모각코 그룹명 정보 추가(https://github.com/boostcampwm2023/web17_morak/pull/209) 또한 반영하였습니다.

## 완료한 기능 명세
- [x] Mogaco 타입에 스키마 변경사항 반영
- [x] 기존 participantList 관련 쿼리 및 mock 코드 삭제

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/8e013b7a-3306-4c67-9286-7ba39ca769fb)
(변경 전/후)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기
