### PR TITLE
[Feat, Refactor] 사용자 본인 가입 그룹 확인 API 및 Swagger 보수

### DIFF
--- a/app/backend/libs/utils/swagger.ts
+++ b/app/backend/libs/utils/swagger.ts
@@ -7,7 +7,7 @@ export function setupSwagger(app: INestApplication): void {
     .setDescription('Morak API description')
     .setVersion('1.0.0')
     .addTag('moraks')
-    .addCookieAuth('refresh_token')
+    .addCookieAuth('token')
     .addBearerAuth(
       {
         type: 'http',

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -61,4 +61,15 @@ export class GroupsController {
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);
   }
+
+  @Get('/my-groups')
+  @ApiOperation({
+    summary: '가입 그룹 확인',
+    description: '해당 사용자가 가입한 그룹을 확인합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully Check', type: [GroupsDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyGroups(@GetUser() member: Member): Promise<Group[]> {
+    return this.groupsService.getMyGroups(member);
+  }
 }

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -84,4 +84,15 @@ export class GroupsRepository {
       },
     });
   }
+
+  async getMyGroups(member: Member): Promise<Group[]> {
+    const groups = await this.prisma.groupToUser.findMany({
+      where: { userId: member.id },
+      include: {
+        group: true,
+      },
+    });
+
+    return groups.map((groupToUser) => groupToUser.group);
+  }
 }

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -21,4 +21,8 @@ export class GroupsService {
   async leaveGroup(id: number, member: Member): Promise<void> {
     return this.groupsRepository.leaveGroup(id, member);
   }
+
+  async getMyGroups(member: Member): Promise<Group[]> {
+    return this.groupsRepository.getMyGroups(member);
+  }
 }

--- a/app/backend/src/member/member.controller.ts
+++ b/app/backend/src/member/member.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Req, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { MemberInformationDto } from './dto/member.dto';
 import { AtGuard } from 'src/auth/guards/at.guard';
@@ -14,9 +14,11 @@ export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 
   @Get('/me')
+  @ApiCookieAuth()
   @ApiOperation({
     summary: '사용자 정보 조회',
-    description: '현재 로그인한 사용자의 정보 조회',
+    description:
+      '현재 로그인한 사용자의 정보를 조회합니다. 해당 사용자 브라우저의 쿠키에 저장되어있는 액세스 토큰을 사용합니다.',
   })
   @ApiResponse({
     status: 200,

--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -61,6 +61,6 @@ export class MogacoWithMemberDto implements ResponseMogacoWithMemberDto {
   @ApiProperty({ description: 'Member information', type: MemberInformationDto })
   member: MemberInformationDto;
 
-  @ApiProperty({ description: 'Participants information', type: ParticipantResponseDto })
+  @ApiProperty({ description: 'Participants information', type: [ParticipantResponseDto] })
   participants: ResponseParticipant[];
 }


### PR DESCRIPTION
## 설명
- close #212 

모각코를 개설할 때 사용자는 본인이 속한 그룹을 알고 그룹을 지정해서 모각코를 개설합니다.
Swagger

## 완료한 기능 명세
- [x] 사용자 본인 가입 그룹 확인 API
- [x] 해당 API Swagger 작성
- [x] 특정 게시글 조회 시 swagger에서 participants [ ]로 response 변경
- [x] /member/me의 경우 bearer_token과 쿠키에도 액세스 토큰이 담아져있어야하므로 그에 맞춰서 swagger 수정

### 스크린샷

### 현재 가입 그룹이 없는 경우
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/a3fb695a-8f18-4678-acaa-e3e35bf82287)

### 그룹 가입
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/3a40d66b-77e2-4f82-b84c-12949b172e7d)

### 가입 그룹 조회
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/4138e412-752c-4efc-90de-03972b51fcab)


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

