### PR TITLE
[Feat] 공통 모달 구현

### DIFF
--- a/app/frontend/src/components/Header/index.css.ts
+++ b/app/frontend/src/components/Header/index.css.ts
@@ -12,7 +12,7 @@ export const container = style({
   alignItems: 'center',
   background: vars.color.grayscaleWhite,
   borderBottom: `1px solid ${vars.color.grayscale100}`,
-  zIndex: '999',
+  zIndex: 10,
 });
 
 export const header = style({

--- a/app/frontend/src/components/Layout/index.tsx
+++ b/app/frontend/src/components/Layout/index.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
-import { Header } from '@/components';
+import { Header, ModalContainer } from '@/components';
 
 import * as styles from './index.css';
 
@@ -11,6 +11,7 @@ export function Layout() {
       <div className={styles.container}>
         <Outlet />
       </div>
+      <ModalContainer />
     </>
   );
 }

--- a/app/frontend/src/components/Modal/InputModal.tsx
+++ b/app/frontend/src/components/Modal/InputModal.tsx
@@ -1,11 +1,11 @@
 import { Input } from '@/components';
+import { useModalAtom } from '@/stores';
 import { sansRegular16 } from '@/styles/font.css';
 
 import { Footer } from './Footer';
 import * as styles from './index.css';
 
 type InputModalProps = {
-  dialogRef: React.RefObject<HTMLDialogElement>;
   description: string;
   confirmButtonText?: string;
   cancelButtonText?: string;
@@ -13,30 +13,32 @@ type InputModalProps = {
 };
 
 export function InputModal({
-  dialogRef,
   description,
   confirmButtonText = '확인',
   cancelButtonText = '취소',
   onClickConfirm,
 }: InputModalProps) {
+  const [open, setOpen] = useModalAtom();
+
   const closeModal = () => {
-    if (!dialogRef.current) return;
-    dialogRef.current.close();
+    setOpen(false);
   };
 
   return (
-    <dialog className={styles.container} ref={dialogRef}>
-      <div className={styles.inputArea}>
-        <div className={sansRegular16}>{description}</div>
-        <Input maxLength={10} />
-      </div>
-      <Footer
-        buttonType="double"
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        closeModal={closeModal}
-        onClickConfirm={onClickConfirm}
-      />
+    <dialog className={styles.container} open={open}>
+      <form method="dialog" className={styles.form}>
+        <div className={styles.inputArea}>
+          <div className={sansRegular16}>{description}</div>
+          <Input maxLength={10} />
+        </div>
+        <Footer
+          buttonType="double"
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          closeModal={closeModal}
+          onClickConfirm={onClickConfirm}
+        />
+      </form>
     </dialog>
   );
 }

--- a/app/frontend/src/components/Modal/ModalContainer.tsx
+++ b/app/frontend/src/components/Modal/ModalContainer.tsx
@@ -1,0 +1,20 @@
+import { createPortal } from 'react-dom';
+
+import { useAtom } from 'jotai';
+
+import { currentModalAtom, modalOpenedAtom } from '@/stores';
+
+import * as styles from './index.css';
+
+export function ModalContainer() {
+  const [open] = useAtom(modalOpenedAtom);
+  const [currentModal] = useAtom(currentModalAtom);
+
+  return createPortal(
+    <div role="dialog">
+      <div className={`${styles.background} ${open ? styles.open : ''}`} />
+      {currentModal}
+    </div>,
+    document.body,
+  );
+}

--- a/app/frontend/src/components/Modal/index.css.ts
+++ b/app/frontend/src/components/Modal/index.css.ts
@@ -1,14 +1,27 @@
 import { style } from '@vanilla-extract/css';
 
+const open = style({});
+
+export const background = style({
+  display: 'none',
+  position: 'absolute',
+  inset: 0,
+  background: 'rgba(14, 31, 24, 0.05)',
+  backdropFilter: 'blur(0.2rem)',
+
+  selectors: {
+    [`${open}&`]: {
+      display: 'block',
+    },
+  },
+});
 export const buttonArea = style({
   display: 'flex',
   justifyContent: 'stretch',
   gap: '1.6rem',
 });
-
 export const container = style({
   display: 'none',
-  flexDirection: 'column',
   position: 'fixed',
   top: '50%',
   left: '50%',
@@ -18,16 +31,18 @@ export const container = style({
   borderRadius: '0.8rem',
   boxShadow: '0 0.4rem 0.8rem rgba(0, 0, 0, 0.25)',
   transform: 'translate(-50%, -50%)',
-  '::backdrop': {
-    background: 'rgba(14, 31, 24, 0.05)',
-    backdropFilter: 'blur(0.2rem)',
-  },
 
   selectors: {
     [`&[open]`]: {
       display: 'flex',
     },
   },
+});
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
 });
 
 export const inputArea = style({
@@ -37,6 +52,8 @@ export const inputArea = style({
   gap: '0.8rem',
   flexGrow: 1,
 });
+
+export { open };
 
 export const textArea = style({
   display: 'flex',

--- a/app/frontend/src/components/Modal/index.css.ts
+++ b/app/frontend/src/components/Modal/index.css.ts
@@ -6,6 +6,7 @@ export const background = style({
   display: 'none',
   position: 'absolute',
   inset: 0,
+  zIndex: 20,
   background: 'rgba(14, 31, 24, 0.05)',
   backdropFilter: 'blur(0.2rem)',
 
@@ -23,6 +24,7 @@ export const buttonArea = style({
 export const container = style({
   display: 'none',
   position: 'fixed',
+  zIndex: 30,
   top: '50%',
   left: '50%',
   minHeight: '20rem',

--- a/app/frontend/src/components/Modal/index.tsx
+++ b/app/frontend/src/components/Modal/index.tsx
@@ -1,10 +1,10 @@
+import { useModalAtom } from '@/stores';
 import { sansBold24, sansRegular16 } from '@/styles/font.css';
 
 import { Footer } from './Footer';
 import * as styles from './index.css';
 
 type ModalProps = {
-  dialogRef: React.RefObject<HTMLDialogElement>;
   title: string;
   content?: string;
   buttonType: 'single' | 'double';
@@ -14,7 +14,6 @@ type ModalProps = {
 };
 
 export function Modal({
-  dialogRef,
   title,
   content = '',
   buttonType,
@@ -22,24 +21,27 @@ export function Modal({
   cancelButtonText = '취소',
   onClickConfirm,
 }: ModalProps) {
+  const [open, setOpen] = useModalAtom();
+
   const closeModal = () => {
-    if (!dialogRef.current) return;
-    dialogRef.current.close();
+    setOpen(false);
   };
 
   return (
-    <dialog className={styles.container} ref={dialogRef}>
-      <div className={styles.textArea}>
-        <div className={sansBold24}>{title}</div>
-        {content && <div className={sansRegular16}>{content}</div>}
-      </div>
-      <Footer
-        buttonType={buttonType}
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        closeModal={closeModal}
-        onClickConfirm={onClickConfirm}
-      />
+    <dialog className={styles.container} open={open}>
+      <form method="dialog" className={styles.form}>
+        <div className={styles.textArea}>
+          <div className={sansBold24}>{title}</div>
+          {content && <div className={sansRegular16}>{content}</div>}
+        </div>
+        <Footer
+          buttonType={buttonType}
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          closeModal={closeModal}
+          onClickConfirm={onClickConfirm}
+        />
+      </form>
     </dialog>
   );
 }

--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -44,7 +44,7 @@ export const wrapper = style({
   position: 'fixed',
   top: '8.6rem',
   left: 0,
-  zIndex: 100,
+  zIndex: 10,
   height: 'calc(100% - 8.6rem)',
   transition: 'transform 0.5s',
 });

--- a/app/frontend/src/components/index.ts
+++ b/app/frontend/src/components/index.ts
@@ -8,6 +8,8 @@ export * from './Layout';
 export * from './Loading';
 export * from './Loading/LoadingIndicator';
 export * from './Map';
+export * from './Modal';
+export * from './Modal/ModalContainer';
 export * from './MogacoItem';
 export * from './Popover';
 export * from './Sidebar';

--- a/app/frontend/src/hooks/index.ts
+++ b/app/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from './useModal';
 export * from './useRouter';
 export * from './useSetUserInfo';

--- a/app/frontend/src/hooks/useModal.ts
+++ b/app/frontend/src/hooks/useModal.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+import { useAtom } from 'jotai';
+
+import { currentModalAtom, modalOpenedAtom } from '@/stores';
+
+export const useModal = () => {
+  const [, setOpen] = useAtom(modalOpenedAtom);
+  const [, setCurrentModal] = useAtom(currentModalAtom);
+
+  const openModal = (modal: ReactNode) => {
+    setCurrentModal(modal);
+    setOpen(true);
+  };
+
+  return { openModal };
+};

--- a/app/frontend/src/stores/index.ts
+++ b/app/frontend/src/stores/index.ts
@@ -1,2 +1,3 @@
+export * from './modal';
 export * from './mogaco';
 export * from './user';

--- a/app/frontend/src/stores/modal.ts
+++ b/app/frontend/src/stores/modal.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+
+import { atom, useAtom } from 'jotai';
+
+export const currentModalAtom = atom<ReactNode>(null);
+export const modalOpenedAtom = atom<boolean>(false);
+
+export const useModalAtom = () => useAtom(modalOpenedAtom);


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #211
- 모달을 공통으로 사용하기 위한 portal과 hook을 만들었습니다.
- header와 sidebar의 z-index를 조절하였습니다. (header가 999로 설정되어 있었는데 불필요하게 값이 크다고 생각했어요.)
- createPortal을 사용했습니다. `id=root`인 div의 외부에서 모달을 사용합니다. <sup>[[1]](#ref1)</sup>
- `<dialog>` 내에서 `method=dialog`인 form 안에서 버튼을 사용할 경우, ref를 사용하지 않고 모달을 닫을 수 있어 모달 내부 코드를 수정했습니다.
- modal의 열림 상태, 보여 줄 modal을 관리할 atom을 만들었습니다.
- 모달을 사용할 때는 useModal을 사용합니다.
  ```typescript
    const { openModal } = useModal();
    const onClickModal = () => {
      openModal(
        <InputModal onClickConfirm={() => console.log('hi')} description="hi" />,
      );
    };
  ```

## 완료한 기능 명세
- [x] 공통 모달을 사용할 수 있도록 세팅 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


https://github.com/boostcampwm2023/web17_morak/assets/43867711/7b24a08e-8beb-4e14-93d4-c8852975880b


<a id='ref1'>createPortal</a>

 ![image](https://github.com/boostcampwm2023/web17_morak/assets/43867711/cf8d7f4f-c8c5-4043-891c-d748f6b0d5ee)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

