### PR TITLE
[Feat] Calendar API 연결

### DIFF
--- a/app/frontend/src/mocks/mogaco.ts
+++ b/app/frontend/src/mocks/mogaco.ts
@@ -61,7 +61,18 @@ let mogacoList: Mogaco[] = [
 ];
 
 export const mogacoAPIHandlers = [
-  http.get('/mogaco', () => HttpResponse.json<Mogaco[]>(mogacoList)),
+  http.get('/mogaco', ({ request }) => {
+    const url = new URL(request.url);
+    const params = new URLSearchParams(url.search);
+    const date = params.get('date');
+    if (date) {
+      const filteredMogacoList = mogacoList.filter((mogaco) =>
+        mogaco.date.startsWith(date),
+      );
+      return HttpResponse.json<Mogaco[]>(filteredMogacoList);
+    }
+    return HttpResponse.json<Mogaco[]>(mogacoList);
+  }),
   http.post<never, MogacoPostRequest>('/mogaco', async ({ request }) => {
     const body = await request.json();
     const postId = String(Number(mogacoList[mogacoList.length - 1].id) + 1);

--- a/app/frontend/src/pages/Calendar/CalendarView.tsx
+++ b/app/frontend/src/pages/Calendar/CalendarView.tsx
@@ -1,9 +1,15 @@
+import { useState } from 'react';
+
 import { EventClickArg } from '@fullcalendar/core/index.js';
 import koLocale from '@fullcalendar/core/locales/ko';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import FullCalendar from '@fullcalendar/react';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
 
+import { queryKeys } from '@/queries';
 import { vars } from '@/styles';
+import { Mogaco } from '@/types';
 
 import * as styles from './CalendarView.css';
 
@@ -12,27 +18,31 @@ export function CalendarView({
 }: {
   onClickEvent: (dayEvent: EventClickArg) => void;
 }) {
+  const [selectedMonth, setSelectedMonth] = useState(new Date());
+  const refineMogacoList = (mogacoList: Mogaco[]) =>
+    mogacoList.map((mogaco) => {
+      const { id, title, date } = mogaco;
+      return { id, title, date };
+    });
+
+  const { data: mogacoData } = useQuery({
+    ...queryKeys.mogaco.list({ date: dayjs(selectedMonth).format('YYYY-MM') }),
+    select: refineMogacoList,
+  });
+
   return (
     <div className={styles.container}>
       <FullCalendar
+        datesSet={(dateInfo) => setSelectedMonth(dateInfo.view.currentStart)}
         locale={koLocale}
         plugins={[dayGridPlugin]}
         initialView="dayGridMonth"
         weekends
-        events={[
-          {
-            title: '12:00 인천 모각코 이벤트',
-            date: '2023-11-22',
-            id: '1',
-          },
-          {
-            title: '12:00 이수 모각코 이벤트',
-            date: '2023-11-22',
-            id: '2',
-          },
-        ]}
+        events={mogacoData || []}
         eventColor={vars.color.subGreen}
+        eventBackgroundColor={vars.color.subGreen}
         eventTextColor={vars.color.grayscale500}
+        eventDisplay="block"
         eventClick={onClickEvent}
       />
     </div>

--- a/app/frontend/src/pages/Calendar/CalendarView.tsx
+++ b/app/frontend/src/pages/Calendar/CalendarView.tsx
@@ -10,6 +10,8 @@ import { vars } from '@/styles';
 import * as styles from './CalendarView.css';
 import { useCalendarMogacoQuery } from './useMogacoQuery';
 
+const { subGreen, grayscale500 } = vars.color;
+
 export function CalendarView({
   onClickEvent,
 }: {
@@ -28,9 +30,9 @@ export function CalendarView({
         initialView="dayGridMonth"
         weekends
         events={mogacoData || []}
-        eventColor={vars.color.subGreen}
-        eventBackgroundColor={vars.color.subGreen}
-        eventTextColor={vars.color.grayscale500}
+        eventColor={subGreen}
+        eventBackgroundColor={subGreen}
+        eventTextColor={grayscale500}
         eventDisplay="block"
         eventClick={onClickEvent}
       />

--- a/app/frontend/src/pages/Calendar/CalendarView.tsx
+++ b/app/frontend/src/pages/Calendar/CalendarView.tsx
@@ -4,14 +4,11 @@ import { EventClickArg } from '@fullcalendar/core/index.js';
 import koLocale from '@fullcalendar/core/locales/ko';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import FullCalendar from '@fullcalendar/react';
-import { useQuery } from '@tanstack/react-query';
-import dayjs from 'dayjs';
 
-import { queryKeys } from '@/queries';
 import { vars } from '@/styles';
-import { Mogaco } from '@/types';
 
 import * as styles from './CalendarView.css';
+import { useCalendarMogacoQuery } from './useMogacoQuery';
 
 export function CalendarView({
   onClickEvent,
@@ -19,16 +16,8 @@ export function CalendarView({
   onClickEvent: (dayEvent: EventClickArg) => void;
 }) {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
-  const refineMogacoList = (mogacoList: Mogaco[]) =>
-    mogacoList.map((mogaco) => {
-      const { id, title, date } = mogaco;
-      return { id, title, date };
-    });
 
-  const { data: mogacoData } = useQuery({
-    ...queryKeys.mogaco.list({ date: dayjs(selectedMonth).format('YYYY-MM') }),
-    select: refineMogacoList,
-  });
+  const { data: mogacoData } = useCalendarMogacoQuery(selectedMonth);
 
   return (
     <div className={styles.container}>

--- a/app/frontend/src/pages/Calendar/useMogacoQuery.ts
+++ b/app/frontend/src/pages/Calendar/useMogacoQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+
+import { queryKeys } from '@/queries';
+import type { Mogaco } from '@/types';
+
+const refineMogacoList = (mogacoList: Mogaco[]) =>
+  mogacoList.map((mogaco) => {
+    const { id, title, date } = mogaco;
+    return { id, title, date };
+  });
+
+export const useCalendarMogacoQuery = (selectedDate: Date) =>
+  useQuery({
+    ...queryKeys.mogaco.list({ date: dayjs(selectedDate).format('YYYY-MM') }),
+    select: refineMogacoList,
+  });

--- a/app/frontend/src/pages/Calendar/useMogacoQuery.ts
+++ b/app/frontend/src/pages/Calendar/useMogacoQuery.ts
@@ -5,10 +5,7 @@ import { queryKeys } from '@/queries';
 import type { Mogaco } from '@/types';
 
 const refineMogacoList = (mogacoList: Mogaco[]) =>
-  mogacoList.map((mogaco) => {
-    const { id, title, date } = mogaco;
-    return { id, title, date };
-  });
+  mogacoList.map(({ id, title, date }) => ({ id, title, date }));
 
 export const useCalendarMogacoQuery = (selectedDate: Date) =>
   useQuery({

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -3,9 +3,9 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { mogaco } from '@/services';
 
 export const mogacoKeys = createQueryKeys('mogaco', {
-  list: (filters?: { filters: { page: number } }) => ({
+  list: (filters?: { date?: string }) => ({
     queryKey: [{ filters }],
-    queryFn: () => mogaco.list(),
+    queryFn: () => mogaco.list(filters),
   }),
   detail: (id: string) => ({
     queryKey: [id],

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -7,8 +7,13 @@ export const mogaco = {
     index: '/mogaco',
   },
 
-  list: async () => {
-    const { data } = await morakAPI.get<Mogaco[]>(mogaco.endPoint.index);
+  list: async (filters?: { date?: string }) => {
+    const queryString = filters
+      ? `?${new URLSearchParams(filters).toString()}`
+      : '';
+    const { data } = await morakAPI.get<Mogaco[]>(
+      `${mogaco.endPoint.index}${queryString}`,
+    );
     return data;
   },
   detail: async (id: string) => {


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- 캘린더 페이지에서 월별 모각코 기록을 가져와 달력 화면에 보여 줍니다.
- useQuery를 사용해 가져온 데이터를 select 옵션을 사용하여 필터링된 data 값을 리턴할 수 있습니다.
- API 작업 중인 상태이고, mocking으로 작업했습니다.

## 완료한 기능 명세
- [x] 월별 데이터 달력 뷰에 보여 주기 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


https://github.com/boostcampwm2023/web17_morak/assets/43867711/3341313f-b62e-40b8-8262-89721a30eb5e


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

