### PR TITLE
[Refactor/Fix] 불필요한 데이터 반환 제외 및 /member/me API 수정

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -6,6 +6,7 @@ import { AtGuard } from 'src/auth/guards/at.guard';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ParticipantResponseDto } from 'src/mogaco/dto/response-participants.dto';
 import { GroupsDto } from './dto/groups.dto';
+import { MemberInformationDto } from 'src/member/dto/member.dto';
 
 @ApiTags('Group API')
 @Controller('groups')
@@ -33,7 +34,7 @@ export class GroupsController {
   @ApiParam({ name: 'id', description: '조회할 그룹의 Id' })
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [ParticipantResponseDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getAllMembersOfGroup(@Param('id', ParseIntPipe) id: number): Promise<Member[]> {
+  async getAllMembersOfGroup(@Param('id', ParseIntPipe) id: number): Promise<MemberInformationDto[]> {
     return this.groupsService.getAllMembersOfGroup(id);
   }
 

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { Group, Member } from '@prisma/client';
 import { PrismaService } from 'prisma/prisma.service';
+import { MemberInformationDto } from 'src/member/dto/member.dto';
 
 @Injectable()
 export class GroupsRepository {
@@ -10,7 +11,7 @@ export class GroupsRepository {
     return this.prisma.group.findMany();
   }
 
-  async getAllMembersOfGroup(groupId: number): Promise<Member[]> {
+  async getAllMembersOfGroup(groupId: number): Promise<MemberInformationDto[]> {
     return this.prisma.groupToUser
       .findMany({
         where: {
@@ -20,7 +21,14 @@ export class GroupsRepository {
           user: true,
         },
       })
-      .then((groupToUsers) => groupToUsers.map((groupToUser) => groupToUser.user));
+      .then((groupToUsers) =>
+        groupToUsers.map((groupToUser) => ({
+          providerId: groupToUser.user.providerId,
+          email: groupToUser.user.email,
+          nickname: groupToUser.user.nickname,
+          profilePicture: groupToUser.user.profilePicture,
+        })),
+      );
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { GroupsRepository } from './groups.repository';
 import { Group, Member } from '@prisma/client';
+import { MemberInformationDto } from 'src/member/dto/member.dto';
 
 @Injectable()
 export class GroupsService {
@@ -10,7 +11,7 @@ export class GroupsService {
     return this.groupsRepository.getAllGroups();
   }
 
-  async getAllMembersOfGroup(id: number): Promise<Member[]> {
+  async getAllMembersOfGroup(id: number): Promise<MemberInformationDto[]> {
     return this.groupsRepository.getAllMembersOfGroup(id);
   }
 

--- a/app/backend/src/member/member.controller.ts
+++ b/app/backend/src/member/member.controller.ts
@@ -1,10 +1,9 @@
 import { Controller, Get, Req, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { MemberInformationDto } from './dto/member.dto';
 import { AtGuard } from 'src/auth/guards/at.guard';
-import { RequestApiDto } from '@morak/apitype/dto/request/api';
 
 @ApiTags('Member Infomation API')
 @Controller('member')
@@ -14,6 +13,7 @@ export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 
   @Get('/me')
+  @ApiCookieAuth()
   @ApiOperation({
     summary: '사용자 정보 조회',
     description: '현재 로그인한 사용자의 정보 조회',
@@ -26,7 +26,7 @@ export class MemberController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getUserData(@Req() req: Request, @Res() res: Response): Promise<void> {
     try {
-      const encryptedToken: RequestApiDto = { accesToken: req.cookies.access_token };
+      const encryptedToken = req.cookies.access_token;
       const userData = await this.memberService.getUserData(encryptedToken);
 
       res.json(userData);

--- a/app/backend/src/member/member.service.ts
+++ b/app/backend/src/member/member.service.ts
@@ -2,14 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { MemberInformationDto } from './dto/member.dto';
 import { getSecret } from 'vault';
-import { RequestApiDto } from '@morak/apitype/dto/request/api';
 
 @Injectable()
 export class MemberService {
   constructor(private jwtService: JwtService) {}
 
-  async getUserData(encryptedToken: RequestApiDto): Promise<MemberInformationDto> {
-    const decodedAccessToken = this.jwtService.verify(encryptedToken.accesToken, {
+  async getUserData(encryptedToken: string): Promise<MemberInformationDto> {
+    const decodedAccessToken = this.jwtService.verify(encryptedToken, {
       secret: getSecret(`JWT_ACCESS_SECRET`),
     });
     const { providerId, email, nickname, profilePicture } = decodedAccessToken;

--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -9,8 +9,8 @@ export class MogacoDto implements ResponseMogacoDto {
   @ApiProperty({ description: 'ID of the Mogaco', example: '1' })
   id: Bigint;
 
-  @ApiProperty({ description: 'Group ID', example: '1' })
-  groupId: Bigint;
+  // @ApiProperty({ description: 'Group ID', example: '1' })
+  // groupId: Bigint;
 
   @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
   title: string;
@@ -34,9 +34,6 @@ export class MogacoDto implements ResponseMogacoDto {
 export class MogacoWithMemberDto implements ResponseMogacoWithMemberDto {
   @ApiProperty({ description: 'ID of the Mogaco', example: '1' })
   id: Bigint;
-
-  @ApiProperty({ description: 'Group ID', example: '1' })
-  groupId: Bigint;
 
   @ApiProperty({ description: 'Group Title', example: '부스트캠프 웹' })
   groupTitle: string;

--- a/app/backend/src/mogaco/dto/response-participants.dto.ts
+++ b/app/backend/src/mogaco/dto/response-participants.dto.ts
@@ -17,10 +17,4 @@ export class ParticipantResponseDto implements ResponseParticipant {
 
   @ApiProperty({ description: "URL of the user's profile picture", example: 'https://example.com/profile.jpg' })
   profilePicture: string;
-
-  @ApiProperty({ description: 'Social Login Type', example: 'google' })
-  socialType: string;
-
-  @ApiProperty({ description: 'Date of Member creation', example: '2023-11-22T04:55:02.988Z' })
-  createdAt: Date;
 }

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -36,7 +36,7 @@ export class MogacoController {
   @ApiParam({ name: 'id', description: '조회할 모각코의 Id' })
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: MogacoWithMemberDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getMogacoById(@Param('id', ParseIntPipe) id: number): Promise<MogacoDto> {
+  async getMogacoById(@Param('id', ParseIntPipe) id: number): Promise<MogacoWithMemberDto> {
     return this.mogacoService.getMogacoById(id);
   }
 

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -34,9 +34,16 @@ export class MogacoRepository {
 
     const participants = await this.getParticipants(id);
 
+    const participantsDto = participants.map((participant) => ({
+      id: participant.id.toString(),
+      providerId: participant.providerId,
+      email: participant.email,
+      nickname: participant.nickname,
+      profilePicture: participant.profilePicture,
+    }));
+
     return {
       id: mogaco.id.toString(),
-      groupId: mogaco.groupId.toString(),
       groupTitle: mogaco.group.title,
       title: mogaco.title,
       contents: mogaco.contents,
@@ -50,7 +57,7 @@ export class MogacoRepository {
         nickname: mogaco.member.nickname,
         profilePicture: mogaco.member.profilePicture,
       },
-      participants,
+      participants: participantsDto,
     };
   }
 

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { MogacoRepository } from './mogaco.repository';
 import { Member, Mogaco } from '@prisma/client';
 import { MogacoStatus } from './enum/mogaco-status.enum';
-import { MogacoDto } from './dto/response-mogaco.dto';
+import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { CreateMogacoDto } from './dto/create-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
 
@@ -14,7 +14,7 @@ export class MogacoService {
     return this.mogacoRepository.getAllMogaco();
   }
 
-  async getMogacoById(id: number): Promise<MogacoDto> {
+  async getMogacoById(id: number): Promise<MogacoWithMemberDto> {
     return this.mogacoRepository.getMogacoById(id);
   }
 

--- a/packages/apitype/dto/request/api.ts
+++ b/packages/apitype/dto/request/api.ts
@@ -1,3 +1,3 @@
 export interface RequestApiDto {
-  accesToken: string;
+  accessToken: string;
 }

--- a/packages/apitype/dto/response/mogaco.ts
+++ b/packages/apitype/dto/response/mogaco.ts
@@ -4,7 +4,7 @@ import { Bigint } from "../type";
 
 export interface ResponseMogacoDto {
   id: Bigint;
-  groupId: Bigint;
+  //groupId: Bigint;
   title: string;
   contents: string;
   date: Date;
@@ -13,8 +13,15 @@ export interface ResponseMogacoDto {
   status: string;
 }
 
-export interface ResponseMogacoWithMemberDto extends ResponseMogacoDto {
+export interface ResponseMogacoWithMemberDto {
+  id: Bigint;
   groupTitle: string;
+  title: string;
+  contents: string;
+  date: Date;
+  maxHumanCount: number;
+  address: string;
+  status: string;
   member: ResponseMemberDto;
   participants: ResponseParticipant[];
 }

--- a/packages/apitype/dto/response/participant.ts
+++ b/packages/apitype/dto/response/participant.ts
@@ -6,6 +6,4 @@ export interface ResponseParticipant {
   email: string;
   nickname: string;
   profilePicture: string;
-  socialType: string;
-  createdAt: Date;
 }


### PR DESCRIPTION
## 설명
- close #222 
- close #223 

/member/me에 대한 오류를 다시 한번 수정합니다.
id값이나 사용하지 않는 데이터 반환을 최소화합니다.

## 완료한 기능 명세
- [x] 불필요한 데이터 반환 제외
- [x] /member/me API 수정

### 스크린샷
[스크린샷 기록](https://ttaerrim.notion.site/3e8d03ddf9114910bbceb1f34707ce0b?pvs=4)

### 그룹 소속 인원 조회
- id, socialType 같은 값을 제외했습니다.
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/4b5ccaca-6fa3-4fb6-9ef3-cafd9710975b)

### 특정 모각코 조회
- 조회 시 그룹 아이디, 참석자 정보에서는 소셜타입, 생성일에 대한 데이터를 제외하고 보냅니다.
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/cbda30a3-5c19-41e5-ae0d-6c3ee560dd7e)

### /member/me API 수정
- 해당 API는 헤더에 bearer_token으로 액세스 토큰을 넣어 함께 전달합니다.
- 추가적으로 서버에서 요청하는 사용자의 브라우저에서 쿠키를 추출하여서 정보를 반환합니다.
- 고로 클라이언트에서는 bearer_token만 넣어서 전달하고 쿠키가 잘 심어져있다면 정상적으로 동작하는 것으로 기대됩니다.
<img width="779" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/f199c2a2-2d30-4508-98a6-03af6277500d">



## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

