### PR TITLE
[Modify] 글 삭제 버튼 클릭 시 모달 연결

### DIFF
--- a/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailHeaderButtons.tsx
@@ -11,6 +11,8 @@ import {
   useQuitMogacoQuery,
 } from '@/queries/hooks';
 
+import { useDeleteModal } from './useDeleteModal';
+
 type DetailHeaderButtonsProps = {
   id: string;
 };
@@ -36,12 +38,9 @@ export function DetailHeaderButtons({ id }: DetailHeaderButtonsProps) {
     }
   };
 
+  const { openDeleteModal } = useDeleteModal();
   const onClickDelete = () => {
-    // eslint-disable-next-line no-alert
-    const answer = window.confirm('삭제하시겠습니까?');
-    if (answer) {
-      handleDelete();
-    }
+    openDeleteModal({ onClickConfirm: handleDelete });
   };
 
   const onClickEdit = () => {

--- a/app/frontend/src/pages/MogacoDetail/useDeleteModal.tsx
+++ b/app/frontend/src/pages/MogacoDetail/useDeleteModal.tsx
@@ -1,0 +1,21 @@
+import { Modal } from '@/components';
+import { useModal } from '@/hooks';
+
+export const useDeleteModal = () => {
+  const { openModal } = useModal();
+  const openDeleteModal = ({
+    onClickConfirm,
+  }: {
+    onClickConfirm: () => void;
+  }) => {
+    openModal(
+      <Modal
+        buttonType="double"
+        title="삭제하시겠습니까?"
+        onClickConfirm={onClickConfirm}
+      />,
+    );
+  };
+
+  return { openDeleteModal };
+};


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- window.alert로 임시 구현되어 있던 부분 모달로 교체
- useDeleteModal 커스텀 훅 만들어 사용

## 완료한 기능 명세
- [x] 글 삭제 시 모달 노출 후 삭제하기 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


https://github.com/boostcampwm2023/web17_morak/assets/43867711/02b1ead5-8502-4be6-bc92-86ea6d1c545f


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

