### PR TITLE
[Fix] 모각코 아이템에서 인원 표시 제거

### DIFF
--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -4,13 +4,12 @@ import dayjs from 'dayjs';
 
 import { ReactComponent as Calendar } from '@/assets/icons/calendar.svg';
 import { ReactComponent as Map } from '@/assets/icons/map.svg';
-import { ReactComponent as People } from '@/assets/icons/people.svg';
 import { Label } from '@/components';
 import { Mogaco } from '@/types';
 
 import * as styles from './index.css';
 
-type MogacoProps = Omit<Mogaco, 'member'>;
+type MogacoProps = Mogaco;
 
 export function MogacoItem({
   id,
@@ -20,8 +19,6 @@ export function MogacoItem({
   date,
   address,
   status,
-  maxHumanCount,
-  participants,
 }: MogacoProps) {
   const MogacoLabel = (
     <Label theme="primary" shape="fill" disabled={status === '마감'}>
@@ -39,12 +36,6 @@ export function MogacoItem({
       <div className={styles.content}>
         <div className={styles.detail}>{contents}</div>
         <div className={styles.info}>
-          <div className={styles.infoContent}>
-            <People className={styles.icon} width={16} height={16} />
-            <div className={styles.infoText}>
-              {participants.length}/{maxHumanCount}
-            </div>
-          </div>
           <div className={styles.infoContent}>
             <Map className={styles.icon} width={16} height={16} />
             <div className={styles.infoText}>{address}</div>


### PR DESCRIPTION
## 설명
- 변경된 스키마에 맞게 모각코 아이템에서 인원 수 표시를 제거하였습니다.

## 완료한 기능 명세
- [x] 모각코 아이템에서 인원 표시 제거

### 스크린샷![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/e0f0a84c-3de0-430f-af78-d72b1f900135)

## 리뷰 요청 사항

