### PR TITLE
[Modify] 글 작성 시 가입된 그룹 선택

### DIFF
--- a/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
@@ -35,17 +35,21 @@ export function PostGroupId({
       render={({ field: { onChange } }) => {
         if (groups) {
           return (
-            <select
-              onChange={(event) => onChange(event.target.value)}
-              className={styles.container}
-              disabled={isEdit}
-            >
-              {groups.map((groupItem) => (
-                <option key={groupItem.id} value={groupItem.id}>
-                  {groupItem.title}
-                </option>
-              ))}
-            </select>
+            <>
+              {/* TODO: 그룹 라벨 */}
+              그룹
+              <select
+                onChange={(event) => onChange(event.target.value)}
+                className={styles.container}
+                disabled={isEdit}
+              >
+                {groups.map((groupItem) => (
+                  <option key={groupItem.id} value={groupItem.id}>
+                    {groupItem.title}
+                  </option>
+                ))}
+              </select>
+            </>
           );
         }
         return <>그룹에 가입해 주세요!</>;

--- a/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
@@ -22,7 +22,7 @@ export function PostGroupId({
   const { data: groups } = useQuery(queryKeys.group.myGroup());
 
   useEffect(() => {
-    if (groups) {
+    if (groups && groups.length > 0) {
       setGroup(groups[0].id.toString());
     }
   }, [groups, setGroup]);
@@ -32,28 +32,27 @@ export function PostGroupId({
       control={control}
       name="groupId"
       rules={{ required: true }}
-      render={({ field: { onChange } }) => {
-        if (groups) {
-          return (
-            <>
-              {/* TODO: 그룹 라벨 */}
-              그룹
-              <select
-                onChange={(event) => onChange(event.target.value)}
-                className={styles.container}
-                disabled={isEdit}
-              >
-                {groups.map((groupItem) => (
-                  <option key={groupItem.id} value={groupItem.id}>
-                    {groupItem.title}
-                  </option>
-                ))}
-              </select>
-            </>
-          );
-        }
-        return <>그룹에 가입해 주세요!</>;
-      }}
+      render={({ field: { onChange } }) => (
+        <>
+          {/* TODO: 그룹 라벨 */}
+          <div>그룹</div>
+          {groups && groups.length > 0 ? (
+            <select
+              onChange={(event) => onChange(event.target.value)}
+              className={styles.container}
+              disabled={isEdit}
+            >
+              {groups.map((groupItem) => (
+                <option key={groupItem.id} value={groupItem.id}>
+                  {groupItem.title}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <div>그룹에 가입해 주세요!</div>
+          )}
+        </>
+      )}
     />
   );
 }

--- a/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
@@ -1,7 +1,11 @@
 import { Controller, Control } from 'react-hook-form';
 
+import { ResponseGroupsDto } from '@morak/apitype';
+import { useQuery } from '@tanstack/react-query';
+
 import { Input } from '@/components';
 import { MOGACO_POST } from '@/constants';
+import { queryKeys } from '@/queries';
 import { MogacoPostForm } from '@/types';
 
 type PostGroupIdProps = {
@@ -10,21 +14,34 @@ type PostGroupIdProps = {
 };
 
 export function PostGroupId({ control, isEdit = false }: PostGroupIdProps) {
+  const { data: groups } = useQuery(queryKeys.group.myGroup());
+
   return (
     <Controller
       control={control}
       name="groupId"
       rules={{ required: true }}
       render={({ field: { onChange, value }, fieldState: { error } }) => (
-        <Input
-          label={MOGACO_POST.GROUP.LABEL}
-          placeholder={MOGACO_POST.GROUP.REQUIRED}
-          required
-          disabled={isEdit}
-          onChange={onChange}
-          value={value}
-          errorMessage={error && MOGACO_POST.GROUP.REQUIRED}
-        />
+        <>
+          <Input
+            label={MOGACO_POST.GROUP.LABEL}
+            placeholder={MOGACO_POST.GROUP.REQUIRED}
+            required
+            disabled={isEdit}
+            onChange={onChange}
+            value={value}
+            errorMessage={error && MOGACO_POST.GROUP.REQUIRED}
+          />
+          {groups && (
+            <select onChange={(event) => onChange(event.target.value)}>
+              {groups.map((group: ResponseGroupsDto) => (
+                <option key={group.id} value={group.id}>
+                  {group.title}
+                </option>
+              ))}
+            </select>
+          )}
+        </>
       )}
     />
   );

--- a/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
@@ -23,7 +23,7 @@ export function PostGroupId({
 
   useEffect(() => {
     if (groups && groups.length > 0) {
-      setGroup(groups[0].id.toString());
+      setGroup(groups[0].id);
     }
   }, [groups, setGroup]);
 

--- a/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostGroupId.tsx
@@ -1,48 +1,55 @@
+import { useEffect } from 'react';
 import { Controller, Control } from 'react-hook-form';
 
-import { ResponseGroupsDto } from '@morak/apitype';
 import { useQuery } from '@tanstack/react-query';
 
-import { Input } from '@/components';
-import { MOGACO_POST } from '@/constants';
 import { queryKeys } from '@/queries';
 import { MogacoPostForm } from '@/types';
+
+import * as styles from './group.css';
 
 type PostGroupIdProps = {
   control: Control<MogacoPostForm>;
   isEdit?: boolean;
+  setGroup: (groupId: string) => void;
 };
 
-export function PostGroupId({ control, isEdit = false }: PostGroupIdProps) {
+export function PostGroupId({
+  control,
+  isEdit = false,
+  setGroup,
+}: PostGroupIdProps) {
   const { data: groups } = useQuery(queryKeys.group.myGroup());
+
+  useEffect(() => {
+    if (groups) {
+      setGroup(groups[0].id.toString());
+    }
+  }, [groups, setGroup]);
 
   return (
     <Controller
       control={control}
       name="groupId"
       rules={{ required: true }}
-      render={({ field: { onChange, value }, fieldState: { error } }) => (
-        <>
-          <Input
-            label={MOGACO_POST.GROUP.LABEL}
-            placeholder={MOGACO_POST.GROUP.REQUIRED}
-            required
-            disabled={isEdit}
-            onChange={onChange}
-            value={value}
-            errorMessage={error && MOGACO_POST.GROUP.REQUIRED}
-          />
-          {groups && (
-            <select onChange={(event) => onChange(event.target.value)}>
-              {groups.map((group: ResponseGroupsDto) => (
-                <option key={group.id} value={group.id}>
-                  {group.title}
+      render={({ field: { onChange } }) => {
+        if (groups) {
+          return (
+            <select
+              onChange={(event) => onChange(event.target.value)}
+              className={styles.container}
+              disabled={isEdit}
+            >
+              {groups.map((groupItem) => (
+                <option key={groupItem.id} value={groupItem.id}>
+                  {groupItem.title}
                 </option>
               ))}
             </select>
-          )}
-        </>
-      )}
+          );
+        }
+        return <>그룹에 가입해 주세요!</>;
+      }}
     />
   );
 }

--- a/app/frontend/src/pages/MogacoPost/Controller/group.css.ts
+++ b/app/frontend/src/pages/MogacoPost/Controller/group.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+import { input } from '@/components/Input/index.css';
+
+export const container = style([input]);

--- a/app/frontend/src/pages/MogacoPost/Controller/group.css.ts
+++ b/app/frontend/src/pages/MogacoPost/Controller/group.css.ts
@@ -2,4 +2,4 @@ import { style } from '@vanilla-extract/css';
 
 import { input } from '@/components/Input/index.css';
 
-export const container = style([input]);
+export const container = style([input, { paddingLeft: '0.3rem' }]);

--- a/app/frontend/src/pages/MogacoPost/index.tsx
+++ b/app/frontend/src/pages/MogacoPost/index.tsx
@@ -97,6 +97,7 @@ export function MogacoPostPage() {
         <PostContents control={control} />
       </div>
       <div className={styles.formContent}>
+        {/* TODO: 등록 불가 시 비활성화 처리 */}
         <Button
           type="submit"
           theme="primary"

--- a/app/frontend/src/pages/MogacoPost/index.tsx
+++ b/app/frontend/src/pages/MogacoPost/index.tsx
@@ -31,7 +31,7 @@ export function MogacoPostPage() {
     ...queryKeys.mogaco.detail(postId || ''),
     enabled: !!postId,
   });
-  const { control, handleSubmit, reset } = useForm<MogacoPostForm>({
+  const { control, handleSubmit, reset, setValue } = useForm<MogacoPostForm>({
     defaultValues: {
       title: '',
       address: '',
@@ -50,15 +50,20 @@ export function MogacoPostPage() {
     }
   }, [mogacoData, reset]);
 
+  const setGroup = (groupId: string) => {
+    setValue('groupId', groupId);
+  };
+
   const onSubmit = async ({
     title,
     contents,
     date,
     maxHumanCount,
     address,
+    groupId,
   }: MogacoPostForm) => {
     const formData = {
-      groupId: '1', // 그룹 기능 추가 이전
+      groupId,
       title,
       contents,
       date: new Date(date).toISOString(),
@@ -81,7 +86,11 @@ export function MogacoPostPage() {
       <PostTitle control={control} />
       <div className={styles.formContent}>
         <PostMember />
-        <PostGroupId control={control} isEdit={!!mogacoData} />
+        <PostGroupId
+          control={control}
+          isEdit={!!mogacoData}
+          setGroup={setGroup}
+        />
         <PostMaxHumanCount control={control} isEdit={!!mogacoData} />
         <PostAddress control={control} />
         <PostDate control={control} isEdit={!!mogacoData} />

--- a/app/frontend/src/queries/group.ts
+++ b/app/frontend/src/queries/group.ts
@@ -1,0 +1,10 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+import { group } from '@/services';
+
+export const groupKeys = createQueryKeys('group', {
+  myGroup: () => ({
+    queryKey: ['myGroup'],
+    queryFn: () => group.myGroup(),
+  }),
+});

--- a/app/frontend/src/queries/index.ts
+++ b/app/frontend/src/queries/index.ts
@@ -1,5 +1,6 @@
 import { mergeQueryKeys } from '@lukemorales/query-key-factory';
 
+import { groupKeys } from './group';
 import { mogacoKeys } from './mogaco';
 
-export const queryKeys = mergeQueryKeys(mogacoKeys);
+export const queryKeys = mergeQueryKeys(groupKeys, mogacoKeys);

--- a/app/frontend/src/services/group.ts
+++ b/app/frontend/src/services/group.ts
@@ -1,0 +1,16 @@
+import { ResponseGroupsDto } from '@morak/apitype';
+
+import { morakAPI } from './morakAPI';
+
+export const group = {
+  endPoint: {
+    default: '/group',
+  },
+
+  myGroup: async () => {
+    const { data } = await morakAPI.get<ResponseGroupsDto>(
+      group.endPoint.default,
+    );
+    return data;
+  },
+};

--- a/app/frontend/src/services/group.ts
+++ b/app/frontend/src/services/group.ts
@@ -4,12 +4,12 @@ import { morakAPI } from './morakAPI';
 
 export const group = {
   endPoint: {
-    default: '/group',
+    default: '/groups',
   },
 
   myGroup: async () => {
     const { data } = await morakAPI.get<ResponseGroupsDto>(
-      group.endPoint.default,
+      `${group.endPoint.default}/my-groups`,
     );
     return data;
   },

--- a/app/frontend/src/services/group.ts
+++ b/app/frontend/src/services/group.ts
@@ -8,7 +8,7 @@ export const group = {
   },
 
   myGroup: async () => {
-    const { data } = await morakAPI.get<ResponseGroupsDto>(
+    const { data } = await morakAPI.get<ResponseGroupsDto[]>(
       `${group.endPoint.default}/my-groups`,
     );
     return data;

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,2 +1,3 @@
+export * from './group';
 export * from './member';
 export * from './mogaco';


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- 글 작성 시 유저가 가입된 그룹만 선택할 수 있도록 select box로 선택할 수 있게 합니다.
- select box는 디폴트로 그룹의 첫 번째 아이템이 선택된 것처럼 보이나, select를 직접 열어 옵션을 변경하지 않으면 rhf에는 반영되지 않는 이슈가 있어 setValue 메소드로 groups을 받아왔을 때 groupId에 명시적으로 첫 번째로 가지고 있는 그룹의 아이디를 지정해 주었습니다.


- 추가 필요 작업
  - [ ] Input 컴포넌트 라벨과 인풋 분리 예정
  - [ ] 버튼 비활성화 처리

## 완료한 기능 명세
- [x] 글 작성 시 유저가 가입된 그룹만 select로 선택할 수 있도록 처리

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="1440" alt="스크린샷 2023-11-29 17 15 16" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/303b3a76-ed69-4ccb-ba04-adec0121aa13">
<img width="1440" alt="스크린샷 2023-11-29 17 16 49" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/86771a30-0c12-4a96-91bb-8c43ac327e8d">

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

