### PR TITLE
[Feat] 모각코 기간 별 조회 기능

### DIFF
--- a/app/backend/src/mogaco/dto/response-mogaco.dto.ts
+++ b/app/backend/src/mogaco/dto/response-mogaco.dto.ts
@@ -4,13 +4,14 @@ import { MemberInformationDto } from 'src/member/dto/member.dto';
 import { ParticipantResponseDto } from './response-participants.dto';
 import { ResponseParticipant } from '@morak/apitype/dto/response/participant';
 import { Bigint } from '@morak/apitype/dto/type';
+import { GroupsDto } from 'src/groups/dto/groups.dto';
 
 export class MogacoDto implements ResponseMogacoDto {
   @ApiProperty({ description: 'ID of the Mogaco', example: '1' })
   id: Bigint;
 
-  // @ApiProperty({ description: 'Group ID', example: '1' })
-  // groupId: Bigint;
+  @ApiProperty({ description: 'Group ID', example: '1' })
+  groupId: Bigint;
 
   @ApiProperty({ description: 'Title of the Mogaco', example: '사당역 모각코' })
   title: string;
@@ -29,6 +30,18 @@ export class MogacoDto implements ResponseMogacoDto {
 
   @ApiProperty({ description: 'Status of the Mogaco', example: '모집 중' })
   status: string;
+
+  @ApiProperty({ description: 'Created At timestamp', example: '2023-11-25T10:21:35.716Z' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Updated At timestamp', example: '2023-11-25T10:21:35.716Z' })
+  updatedAt: Date;
+
+  @ApiProperty({ description: 'Deleted At timestamp', example: null })
+  deletedAt: Date;
+
+  @ApiProperty({ description: 'Group details', type: GroupsDto })
+  group: GroupsDto;
 }
 
 export class MogacoWithMemberDto implements ResponseMogacoWithMemberDto {

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -1,14 +1,12 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
 import { MogacoService } from './mogaco.service';
 import { Member, Mogaco } from '@prisma/client';
-import { MogacoStatusValidationPipe } from './pipes/mogaco-status-validation.pipe';
-import { MogacoStatus } from './enum/mogaco-status.enum';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MogacoDto, MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
-import { CreateMogacoDto, StatusDto } from './dto/create-mogaco.dto';
+import { CreateMogacoDto } from './dto/create-mogaco.dto';
 
 @ApiTags('Mogaco API')
 @Controller('mogaco')
@@ -63,22 +61,6 @@ export class MogacoController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   async deleteMogaco(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.mogacoService.deleteMogaco(id, member);
-  }
-
-  @Patch('/:id/status')
-  @ApiOperation({
-    summary: '모각코 상태 업데이트',
-    description: '특정 모각코의 상태를 업데이트합니다.',
-  })
-  @ApiParam({ name: 'id', description: '상태를 업데이트할 모각코의 Id' })
-  @ApiBody({ type: StatusDto })
-  @ApiResponse({ status: 200, description: 'Successfully Updated', type: MogacoWithMemberDto })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  updateMogacoStatus(
-    @Param('id', ParseIntPipe) id: number,
-    @Body('status', MogacoStatusValidationPipe) status: MogacoStatus,
-  ): Promise<Mogaco> {
-    return this.mogacoService.updateMogacoStatus(id, status);
   }
 
   @Patch('/:id')

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -1,9 +1,9 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { MogacoService } from './mogaco.service';
 import { Member, Mogaco } from '@prisma/client';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MogacoDto, MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
 import { CreateMogacoDto } from './dto/create-mogaco.dto';
@@ -17,13 +17,18 @@ export class MogacoController {
 
   @Get('/')
   @ApiOperation({
-    summary: '모든 모각코 조회',
-    description: '존재하는 모든 모각코를 조회합니다.\n 배열로 여러 개를 반환합니다.',
+    summary: '모든 모각코 조회 또는 모각코 기간별 조회',
+    description: '존재하는 모든 모각코를 조회하거나, 요청된 기간 사이 존재하는 모각코를 조회합니다.',
   })
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [MogacoDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getAllMogaco(): Promise<Mogaco[]> {
-    return this.mogacoService.getAllMogaco();
+  @ApiQuery({ name: 'date', description: 'Optional. Format: YYYY-MM or YYYY-MM-DD', required: false })
+  async getMogaco(@Query('date') date?: string): Promise<MogacoDto[]> {
+    if (date) {
+      return this.mogacoService.getMogacoByDate(date);
+    } else {
+      return this.mogacoService.getAllMogaco();
+    }
   }
 
   @Get('/:id')

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -2,7 +2,7 @@ import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/commo
 import { PrismaService } from 'prisma/prisma.service';
 import { Member, Mogaco } from '@prisma/client';
 import { MogacoStatus } from './enum/mogaco-status.enum';
-import { MogacoDto, MogacoWithMemberDto } from './dto/response-mogaco.dto';
+import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { CreateMogacoDto } from './dto/create-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
 
@@ -119,17 +119,6 @@ export class MogacoRepository {
     });
   }
 
-  async updateMogacoStatus(mogaco: MogacoDto): Promise<Mogaco> {
-    try {
-      return await this.prisma.mogaco.update({
-        where: { id: BigInt(mogaco.id) },
-        data: { status: mogaco.status },
-      });
-    } catch (error) {
-      throw new Error(`Failed to update Mogaco status: ${error.message}`);
-    }
-  }
-
   async updateMogaco(id: number, updateMogacoDto: CreateMogacoDto, member: Member): Promise<Mogaco> {
     const mogaco = await this.prisma.mogaco.findUnique({
       where: { id },
@@ -150,6 +139,7 @@ export class MogacoRepository {
           title: updateMogacoDto.title,
           contents: updateMogacoDto.contents,
           date: new Date(updateMogacoDto.date),
+          status: updateMogacoDto.status,
           maxHumanCount: updateMogacoDto.maxHumanCount,
           address: updateMogacoDto.address,
         },

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { MogacoRepository } from './mogaco.repository';
 import { Member, Mogaco } from '@prisma/client';
-import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
+import { MogacoDto, MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { CreateMogacoDto } from './dto/create-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
 
@@ -9,7 +9,7 @@ import { ParticipantResponseDto } from './dto/response-participants.dto';
 export class MogacoService {
   constructor(private mogacoRepository: MogacoRepository) {}
 
-  async getAllMogaco(): Promise<Mogaco[]> {
+  async getAllMogaco(): Promise<MogacoDto[]> {
     return this.mogacoRepository.getAllMogaco();
   }
 
@@ -39,5 +39,9 @@ export class MogacoService {
 
   async cancelMogacoJoin(id: number, member: Member): Promise<void> {
     return this.mogacoRepository.cancelMogacoJoin(id, member);
+  }
+
+  async getMogacoByDate(date: string): Promise<MogacoDto[]> {
+    return this.mogacoRepository.getMogacoByDate(date);
   }
 }

--- a/app/backend/src/mogaco/mogaco.service.ts
+++ b/app/backend/src/mogaco/mogaco.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { MogacoRepository } from './mogaco.repository';
 import { Member, Mogaco } from '@prisma/client';
-import { MogacoStatus } from './enum/mogaco-status.enum';
 import { MogacoWithMemberDto } from './dto/response-mogaco.dto';
 import { CreateMogacoDto } from './dto/create-mogaco.dto';
 import { ParticipantResponseDto } from './dto/response-participants.dto';
@@ -24,12 +23,6 @@ export class MogacoService {
 
   async deleteMogaco(id: number, member: Member): Promise<void> {
     return this.mogacoRepository.deleteMogaco(id, member);
-  }
-
-  async updateMogacoStatus(id: number, status: MogacoStatus): Promise<Mogaco> {
-    const mogaco = await this.getMogacoById(id);
-    mogaco.status = status;
-    return this.mogacoRepository.updateMogacoStatus(mogaco);
   }
 
   async updateMogaco(id: number, updateMogacoDto: CreateMogacoDto, member: Member) {

--- a/packages/apitype/dto/response/mogaco.ts
+++ b/packages/apitype/dto/response/mogaco.ts
@@ -1,16 +1,21 @@
 import { ResponseMemberDto } from "./member";
 import { ResponseParticipant } from "./participant";
 import { Bigint } from "../type";
+import { GroupsDto } from "src/groups/dto/groups.dto";
 
 export interface ResponseMogacoDto {
   id: Bigint;
-  //groupId: Bigint;
+  groupId: Bigint;
   title: string;
   contents: string;
   date: Date;
   maxHumanCount: number;
   address: string;
   status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+  group: GroupsDto;
 }
 
 export interface ResponseMogacoWithMemberDto {


### PR DESCRIPTION
## 설명
- close #234 

기간 별로 게시글을 조회합니다.
'2023-11', '2023-11-23' 둘 다 인식하도록 동작합니다.
다만 월은 무조건 두 자릿수로 '2023-04' 이런 식으로 작성이 되어야 합니다.

엔드포인트를 통일하기 위해 컨트롤러단에서 두 기능을 분기하였습니다.
NestJS의 라우팅 시스템으로 인해 상당한 양의 고통을 받았습니다.

[NestJS 라우팅으로 인한 오류 정리](https://velog.io/@ldhbenecia/NestJS-Validation-failed-%EB%9D%BC%EC%9A%B0%ED%8C%85-%EC%8B%9C%EC%8A%A4%ED%85%9C%EC%9C%BC%EB%A1%9C-%EC%9D%B8%ED%95%9C-%EC%98%A4%EB%A5%98)

## 완료한 기능 명세
- [x] updateStatus 불필요한 코드 제거
- [x] 모각코 기간 별 조회 기능
- [x] Swagger
- [x] 엔드포인트 통일

### 스크린샷
### 모든 모각코 조회
<img width="631" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/084c8cc5-d227-4f67-b704-c458d75881d3">


### 특정 기간 조회
<img width="697" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/f896d147-28fa-4820-a2aa-48ba9ef69b2e">


### 그 기간에 없을 경우
<img width="600" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/43f7a0b9-7136-4d69-add1-a2963965f763">


## 리뷰 요청 사항
x

