### PR TITLE
[Fix] 모각코 데이터의 좌표값이 없는 경우 처리

### DIFF
--- a/app/frontend/src/components/Map/index.tsx
+++ b/app/frontend/src/components/Map/index.tsx
@@ -25,14 +25,16 @@ export function Map({ onClickMarker }: MapProps) {
 
     mogacoList?.forEach((mogaco) => {
       const { coord, id } = mogaco;
-      const [lat, lon] = coord.split(',');
-      const marker = new Tmapv3.Marker({
-        position: new Tmapv3.LatLng(Number(lat), Number(lon)),
-        icon: '/public/assets/icons/pin.svg',
-        map: mapContent,
-      });
-      marker.id = id;
-      marker.on('Click', onClickMarker);
+      if (coord) {
+        const [lat, lon] = coord.split(',');
+        const marker = new Tmapv3.Marker({
+          position: new Tmapv3.LatLng(Number(lat), Number(lon)),
+          icon: '/public/assets/icons/pin.svg',
+          map: mapContent,
+        });
+        marker.id = id;
+        marker.on('Click', onClickMarker);
+      }
     });
 
     return () => {


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- 모각코 데이터의 좌표값이 없는 경우 마커를 찍는 과정에서 지도가 정상적으로 렌더링되지 않습니다.
- 좌표값이 있을 때만 마커를 찍도록 수정하였습니다.
- #238 에서 언급된 `Property 'coord' does not exist on type 'ResponseMogacoDto'.` 에러와는 상관 없습니다.

## 완료한 기능 명세
- [x] 모각코 데이터의 좌표값이 없는 경우 마커를 찍지 않도록 수정

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

