### PR TITLE
[Refactor] 멘토링 피드백 반영

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -46,6 +46,8 @@ export class GroupsController {
   @ApiParam({ name: 'id', description: '참가할 그룹의 Id' })
   @ApiResponse({ status: 201, description: 'Successfully join' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Group with id not found' })
   async joinGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.joinGroup(id, member);
   }
@@ -59,6 +61,7 @@ export class GroupsController {
   @ApiResponse({ status: 200, description: 'Successfully leaved join' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Group with id not found' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);
   }

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -8,27 +8,25 @@ export class GroupsRepository {
   constructor(private prisma: PrismaService) {}
 
   async getAllGroups(): Promise<Group[]> {
-    return this.prisma.group.findMany();
+    return await this.prisma.group.findMany();
   }
 
   async getAllMembersOfGroup(groupId: number): Promise<MemberInformationDto[]> {
-    return this.prisma.groupToUser
-      .findMany({
-        where: {
-          groupId: groupId,
-        },
-        include: {
-          user: true,
-        },
-      })
-      .then((groupToUsers) =>
-        groupToUsers.map((groupToUser) => ({
-          providerId: groupToUser.user.providerId,
-          email: groupToUser.user.email,
-          nickname: groupToUser.user.nickname,
-          profilePicture: groupToUser.user.profilePicture,
-        })),
-      );
+    const groupToUsers = await this.prisma.groupToUser.findMany({
+      where: {
+        groupId: groupId,
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    return groupToUsers.map((groupToUser) => ({
+      providerId: groupToUser.user.providerId,
+      email: groupToUser.user.email,
+      nickname: groupToUser.user.nickname,
+      profilePicture: groupToUser.user.profilePicture,
+    }));
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {

--- a/app/backend/src/mogaco/mogaco.controller.ts
+++ b/app/backend/src/mogaco/mogaco.controller.ts
@@ -39,6 +39,7 @@ export class MogacoController {
   @ApiParam({ name: 'id', description: '조회할 모각코의 Id' })
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: MogacoWithMemberDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Mogaco with id not found' })
   async getMogacoById(@Param('id', ParseIntPipe) id: number): Promise<MogacoWithMemberDto> {
     return this.mogacoService.getMogacoById(id);
   }
@@ -78,6 +79,7 @@ export class MogacoController {
   @ApiResponse({ status: 200, description: 'Successfully updated', type: MogacoWithMemberDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Mogaco with id not found' })
   async updateMogaco(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateMogacoDto: CreateMogacoDto,
@@ -94,6 +96,7 @@ export class MogacoController {
   @ApiParam({ name: 'id', description: '참가할 모각코의 Id' })
   @ApiResponse({ status: 201, description: 'Successfully join' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   async joinMogaco(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.mogacoService.joinMogaco(id, member);
   }
@@ -119,6 +122,7 @@ export class MogacoController {
   @ApiResponse({ status: 200, description: 'Successfully cancelled join' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Mogaco with id not found' })
   async cancelMogacoJoin(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.mogacoService.cancelMogacoJoin(id, member);
   }

--- a/app/backend/src/mogaco/mogaco.repository.ts
+++ b/app/backend/src/mogaco/mogaco.repository.ts
@@ -18,9 +18,6 @@ export class MogacoRepository {
       },
     });
 
-    if (!mogacos) {
-      throw new NotFoundException('No Mogaco events found');
-    }
     return mogacos.map((mogaco) => ({
       id: mogaco.id.toString(),
       groupId: mogaco.group.id.toString(),
@@ -279,7 +276,7 @@ export class MogacoRepository {
       where: {
         date: {
           gte: startDate,
-          lt: endDate,
+          lte: endDate,
         },
       },
       include: {


### PR DESCRIPTION

## 설명
- close #247 
groups API 코드에서 async 메소드로 잡혀있는데 그 안에는 then으로 받더라
시간 제한 둘 때 이상-이하보다는 이상-미만이 더 안전하다고 생각
getAllMogaco(): mogaco 없으면 404 응답하던데 응답 형식은 array더라, 이 경우 404가 조금 애매함. API endpoint가 없어서인지 결과가 없어서인지 애매.
⇒ 결과 데이터 0개는 null이 아님. 공집합.
⇒ 한 개가 아닌 n개의 데이터를 내려주는 경우 공집합도 데이터가 존재하는 걸로 침

 Prisma에서 Date 관련 구문 gte(이상), lte(이하), gt(초과), lt(미만)으로 되어있으나 현재

```typescript
    // 231129 ldhbenecia | 사용자가 날짜만 입력한 경우 (e.g., '2023-11')
    if (date.length === 7) {
      startDate = new Date(`${date}-01T00:00:00.000Z`);
      endDate = new Date(`${date}-31T23:59:59.999Z`);
    } else {
      // 231129 ldhbenecia | 사용자가 날짜와 일자를 입력한 경우 (e.g., '2023-11-25')
      startDate = new Date(`${date}T00:00:00.000Z`);
      endDate = new Date(`${date}T23:59:59.999Z`);
```

여기서 이상, 미만으로 바꾸라는 피드백을 받아서 본래 gte, lt로 이상, 미만으로 받았으나 이상, 이하로 해결함
gte, lte 사용

## 완료한 기능 명세
- [x] async 구문에 맞는 문법으로 변경
- [x] Prisma에서 Date 관련 구문 수정
- [x] Swagger 에러코드 추가

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

