### PR TITLE
[Feat] 폼 작성 시 장소 API를 통해 입력 

### DIFF
--- a/app/frontend/src/components/Button/index.tsx
+++ b/app/frontend/src/components/Button/index.tsx
@@ -7,7 +7,7 @@ type ButtonProps = {
   size: 'small' | 'medium' | 'large';
   disabled?: boolean;
   fullWidth?: boolean;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
   className?: string;
 };

--- a/app/frontend/src/components/Input/index.tsx
+++ b/app/frontend/src/components/Input/index.tsx
@@ -1,5 +1,3 @@
-import { HTMLInputTypeAttribute } from 'react';
-
 import * as styles from './index.css';
 import { FieldLabel } from '../FieldLabel';
 
@@ -7,7 +5,7 @@ type InputProps = {
   label?: string;
   placeholder?: string;
   errorMessage?: string;
-  type?: HTMLInputTypeAttribute;
+  type?: React.HTMLInputTypeAttribute;
   disabled?: boolean;
   maxLength?: number;
   min?: number | string;
@@ -15,7 +13,7 @@ type InputProps = {
   required?: boolean;
   defaultValue?: string;
   value?: string | number;
-  onChange?: () => void;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onClick?: React.MouseEventHandler<HTMLInputElement>;
   list?: string;
 };

--- a/app/frontend/src/components/Modal/MapModal.css.ts
+++ b/app/frontend/src/components/Modal/MapModal.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 
 import { vars } from '@/styles';
 import { sansRegular12 } from '@/styles/font.css';
@@ -6,7 +7,12 @@ import { sansRegular12 } from '@/styles/font.css';
 import { container as modalContainer } from './index.css';
 
 const { grayscale500, grayscale200, grayscale50 } = vars.color;
-
+export const addressWrapper = style({
+  display: 'flex',
+  flex: '1',
+  gap: '0.8rem',
+  maxHeight: calc.subtract('100%', '7.8rem'),
+});
 export const buttonWrapper = style({
   display: 'flex',
   gap: '0.4rem',
@@ -18,6 +24,12 @@ export const container = style([
     height: '90%',
   },
 ]);
+export const currentAddress = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '0.4rem',
+});
 
 export const form = style({
   width: '100%',
@@ -40,20 +52,26 @@ export const list = style([
     width: ['100%', '-webkit-fill-available'],
     outline: 'none',
     border: `2px solid ${grayscale200}`,
-    borderBottom: `none`,
     borderRadius: '0.4rem',
     marginTop: '0.4rem',
+    overflowY: 'auto',
+    cursor: 'pointer',
   },
 ]);
 
 export const listItem = style({
   selectors: {
-    [`&:hover`]: {
-      backgroundColor: grayscale50,
-    },
     [`${list} &`]: {
       padding: '0.8rem',
       borderBottom: `2px solid ${grayscale200}`,
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    [`&:hover`]: {
+      backgroundColor: grayscale50,
+    },
+    [`${list} &:last-child`]: {
+      borderBottom: `none`,
     },
   },
 });

--- a/app/frontend/src/components/Modal/MapModal.css.ts
+++ b/app/frontend/src/components/Modal/MapModal.css.ts
@@ -11,7 +11,7 @@ export const addressWrapper = style({
   display: 'flex',
   flex: '1',
   gap: '0.8rem',
-  maxHeight: calc.subtract('100%', '7.8rem'),
+  maxHeight: calc.subtract('100%', '5.7rem'),
 });
 export const buttonWrapper = style({
   display: 'flex',

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -1,13 +1,24 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
 
 import { Button, Input } from '@/components';
+import { queryKeys } from '@/queries';
 import { useModalAtom } from '@/stores';
 
 import * as styles from './MapModal.css';
 
 export function MapModal() {
   const [open, setOpen] = useModalAtom();
+  const [searchKeyword, setSearchKeyword] = useState('');
   const mapRef = useRef<HTMLDivElement>(null);
+  const { data: tmapResponse } = useQuery({
+    ...queryKeys.tmap.searchAddress({
+      searchKeyword,
+    }),
+    enabled: !!searchKeyword,
+  });
+  const addressData = tmapResponse?.searchPoiInfo?.pois?.poi;
 
   const closeModal = () => {
     setOpen(false);
@@ -29,13 +40,27 @@ export function MapModal() {
     <dialog className={styles.container} open={open}>
       <form method="dialog" className={styles.form}>
         <div className={styles.inputWrapper}>
-          <Input list="address-input" />
+          <Input
+            list="address-input"
+            value={searchKeyword}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setSearchKeyword(e.currentTarget.value)
+            }
+          />
           <datalist id="address-input" className={styles.list}>
-            {['A', 'B', 'C', 'D'].map((item) => (
-              <option key={item} className={styles.listItem}>
-                {item}
-              </option>
-            ))}
+            {addressData?.map((address) => {
+              const fullAddress =
+                address.newAddressList.newAddress[0].fullAddressRoad;
+              const addressName = address.name;
+              return (
+                <option
+                  key={address.pkey}
+                  value={`${fullAddress} ${addressName}`}
+                >
+                  {`${fullAddress} ${addressName}`}
+                </option>
+              );
+            })}
           </datalist>
         </div>
         <div id="map" className={styles.map} ref={mapRef} />

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -16,6 +16,7 @@ type MapModalProps = {
 export function MapModal({ saveAddress }: MapModalProps) {
   const [open, setOpen] = useModalAtom();
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [selectedAddress, setSelectedAddress] = useState('');
   const mapRef = useRef<HTMLDivElement>(null);
   const { data: tmapResponse } = useQuery({
     ...queryKeys.tmap.searchAddress({
@@ -30,7 +31,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
   };
 
   const onClickConfirm = () => {
-    saveAddress({ address: searchKeyword });
+    saveAddress({ address: selectedAddress });
     closeModal();
   };
 
@@ -51,6 +52,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
       <form method="dialog" className={styles.form}>
         <div className={styles.currentAddress}>
           <span className={sansRegular14}> 선택한 주소: </span>
+          <span className={sansBold14}>{selectedAddress}</span>
         </div>
         <div className={styles.addressWrapper}>
           <div className={styles.inputWrapper}>
@@ -71,6 +73,12 @@ export function MapModal({ saveAddress }: MapModalProps) {
                     className={styles.listItem}
                     key={address.pkey}
                     value={`${fullAddress} ${addressName}`}
+                    onClick={(e) =>
+                      setSelectedAddress(
+                        e.currentTarget.getAttribute('value') || '',
+                      )
+                    }
+                    aria-hidden
                   >
                     <span className={sansBold14}>{addressName}</span>
                     <span className={sansRegular12}>{fullAddress}</span>
@@ -81,7 +89,6 @@ export function MapModal({ saveAddress }: MapModalProps) {
           </div>
           <div id="map" className={styles.map} ref={mapRef} />
         </div>
-        <div id="map" className={styles.map} ref={mapRef} />
         <div className={styles.buttonWrapper}>
           <Button
             type="button"

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -26,7 +26,11 @@ export function MapModal({ saveAddress }: MapModalProps) {
   });
   const addressData = tmapResponse?.searchPoiInfo?.pois?.poi;
 
+  const resetSearchKeyword = () => {
+    setSearchKeyword('');
+  };
   const closeModal = () => {
+    resetSearchKeyword();
     setOpen(false);
   };
 

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -51,6 +51,12 @@ export function MapModal({ saveAddress }: MapModalProps) {
     mapContent.setZoomLimit(7, 16);
   }, [mapRef]);
 
+  const onClickAddressListItem = <
+    Event extends React.MouseEvent | React.KeyboardEvent,
+  >(
+    e: Event,
+  ) => setSelectedAddress(e.currentTarget.getAttribute('value') || '');
+
   return (
     <dialog className={styles.container} open={open}>
       <form method="dialog" className={styles.form}>
@@ -75,15 +81,13 @@ export function MapModal({ saveAddress }: MapModalProps) {
                   const addressName = address.name;
                   return (
                     <li
+                      role="option"
+                      aria-selected={false}
                       className={styles.listItem}
                       key={address.pkey}
                       value={`${fullAddress} ${addressName}`}
-                      onClick={(e) =>
-                        setSelectedAddress(
-                          e.currentTarget.getAttribute('value') || '',
-                        )
-                      }
-                      aria-hidden
+                      onClick={onClickAddressListItem}
+                      onKeyDown={onClickAddressListItem}
                     >
                       <span className={sansBold14}>{addressName}</span>
                       <span className={sansRegular12}>{fullAddress}</span>

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { RequestCreateMogacoDto } from '@morak/apitype';
 import { useQuery } from '@tanstack/react-query';
 
 import { Button, Input } from '@/components';
@@ -8,7 +9,10 @@ import { useModalAtom } from '@/stores';
 
 import * as styles from './MapModal.css';
 
-export function MapModal() {
+type MapModalProps = {
+  saveAddress: ({ address }: Pick<RequestCreateMogacoDto, 'address'>) => void;
+};
+export function MapModal({ saveAddress }: MapModalProps) {
   const [open, setOpen] = useModalAtom();
   const [searchKeyword, setSearchKeyword] = useState('');
   const mapRef = useRef<HTMLDivElement>(null);
@@ -22,6 +26,11 @@ export function MapModal() {
 
   const closeModal = () => {
     setOpen(false);
+  };
+
+  const onClickConfirm = () => {
+    saveAddress({ address: searchKeyword });
+    closeModal();
   };
 
   useEffect(() => {
@@ -81,7 +90,7 @@ export function MapModal() {
             size="medium"
             shape="fill"
             fullWidth
-            onClick={closeModal}
+            onClick={onClickConfirm}
           >
             확인
           </Button>

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Button, Input } from '@/components';
 import { queryKeys } from '@/queries';
 import { useModalAtom } from '@/stores';
+import { sansBold14, sansRegular12, sansRegular14 } from '@/styles/font.css';
 
 import * as styles from './MapModal.css';
 
@@ -48,29 +49,37 @@ export function MapModal({ saveAddress }: MapModalProps) {
   return (
     <dialog className={styles.container} open={open}>
       <form method="dialog" className={styles.form}>
-        <div className={styles.inputWrapper}>
-          <Input
-            list="address-input"
-            value={searchKeyword}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setSearchKeyword(e.currentTarget.value)
-            }
-          />
-          <datalist id="address-input" className={styles.list}>
-            {addressData?.map((address) => {
-              const fullAddress =
-                address.newAddressList.newAddress[0].fullAddressRoad;
-              const addressName = address.name;
-              return (
-                <option
-                  key={address.pkey}
-                  value={`${fullAddress} ${addressName}`}
-                >
-                  {`${fullAddress} ${addressName}`}
-                </option>
-              );
-            })}
-          </datalist>
+        <div className={styles.currentAddress}>
+          <span className={sansRegular14}> 선택한 주소: </span>
+        </div>
+        <div className={styles.addressWrapper}>
+          <div className={styles.inputWrapper}>
+            <Input
+              list="address-input"
+              value={searchKeyword}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setSearchKeyword(e.currentTarget.value)
+              }
+            />
+            <ul id="address-input" className={styles.list}>
+              {addressData?.map((address) => {
+                const fullAddress =
+                  address.newAddressList.newAddress[0].fullAddressRoad;
+                const addressName = address.name;
+                return (
+                  <li
+                    className={styles.listItem}
+                    key={address.pkey}
+                    value={`${fullAddress} ${addressName}`}
+                  >
+                    <span className={sansBold14}>{addressName}</span>
+                    <span className={sansRegular12}>{fullAddress}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+          <div id="map" className={styles.map} ref={mapRef} />
         </div>
         <div id="map" className={styles.map} ref={mapRef} />
         <div className={styles.buttonWrapper}>

--- a/app/frontend/src/components/Modal/MapModal.tsx
+++ b/app/frontend/src/components/Modal/MapModal.tsx
@@ -55,7 +55,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
     <dialog className={styles.container} open={open}>
       <form method="dialog" className={styles.form}>
         <div className={styles.currentAddress}>
-          <span className={sansRegular14}> 선택한 주소: </span>
+          <span className={sansRegular14}>선택한 주소: </span>
           <span className={sansBold14}>{selectedAddress}</span>
         </div>
         <div className={styles.addressWrapper}>
@@ -67,29 +67,31 @@ export function MapModal({ saveAddress }: MapModalProps) {
                 setSearchKeyword(e.currentTarget.value)
               }
             />
-            <ul id="address-input" className={styles.list}>
-              {addressData?.map((address) => {
-                const fullAddress =
-                  address.newAddressList.newAddress[0].fullAddressRoad;
-                const addressName = address.name;
-                return (
-                  <li
-                    className={styles.listItem}
-                    key={address.pkey}
-                    value={`${fullAddress} ${addressName}`}
-                    onClick={(e) =>
-                      setSelectedAddress(
-                        e.currentTarget.getAttribute('value') || '',
-                      )
-                    }
-                    aria-hidden
-                  >
-                    <span className={sansBold14}>{addressName}</span>
-                    <span className={sansRegular12}>{fullAddress}</span>
-                  </li>
-                );
-              })}
-            </ul>
+            {addressData && (
+              <ul id="address-input" className={styles.list}>
+                {addressData.map((address) => {
+                  const fullAddress =
+                    address.newAddressList.newAddress[0].fullAddressRoad;
+                  const addressName = address.name;
+                  return (
+                    <li
+                      className={styles.listItem}
+                      key={address.pkey}
+                      value={`${fullAddress} ${addressName}`}
+                      onClick={(e) =>
+                        setSelectedAddress(
+                          e.currentTarget.getAttribute('value') || '',
+                        )
+                      }
+                      aria-hidden
+                    >
+                      <span className={sansBold14}>{addressName}</span>
+                      <span className={sansRegular12}>{fullAddress}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </div>
           <div id="map" className={styles.map} ref={mapRef} />
         </div>

--- a/app/frontend/src/constants/env.ts
+++ b/app/frontend/src/constants/env.ts
@@ -1,0 +1,1 @@
+export const TMAP_API_KEY = 'F5KgoZ8bWF1IR9Lin2t0V4zxO3ISI7ndSO8EsEq1';

--- a/app/frontend/src/constants/index.ts
+++ b/app/frontend/src/constants/index.ts
@@ -2,5 +2,6 @@ export * from './Header';
 export * from './Main';
 export * from './MogacoDetail';
 export * from './MogacoPost';
+export * from './env';
 export * from './path';
 export * from './url';

--- a/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
@@ -1,13 +1,10 @@
-import { ChangeEvent, useState } from 'react';
 import { Controller, Control } from 'react-hook-form';
 
 import { RequestCreateMogacoDto } from '@morak/apitype';
-import { useQuery } from '@tanstack/react-query';
 
 import { Input, MapModal } from '@/components';
 import { MOGACO_POST } from '@/constants';
 import { useModal } from '@/hooks';
-import { queryKeys } from '@/queries';
 
 type PostAddressProps = {
   control: Control<RequestCreateMogacoDto>;
@@ -18,14 +15,6 @@ export function PostAddress({ control }: PostAddressProps) {
   const onClickInput = () => {
     openModal(<MapModal />);
   };
-  const [searchKeyword, setSearchKeyword] = useState('');
-  const { data: tmapResponse } = useQuery({
-    ...queryKeys.tmap.searchAddress({
-      searchKeyword,
-    }),
-    enabled: !!searchKeyword,
-  });
-  const addressData = tmapResponse?.searchPoiInfo?.pois?.poi;
 
   return (
     <Controller
@@ -33,49 +22,15 @@ export function PostAddress({ control }: PostAddressProps) {
       name="address"
       rules={{ required: true }}
       render={({ field: { onChange, value }, fieldState: { error } }) => (
-        <>
-          <Input
-            label={MOGACO_POST.ADDRESS.LABEL}
-            placeholder={MOGACO_POST.ADDRESS.REQUIRED}
-            required
-            value={searchKeyword || value}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setSearchKeyword(e.currentTarget.value)
-            }
-            errorMessage={error && MOGACO_POST.ADDRESS.REQUIRED}
-            onClick={onClickInput}
-          />
-          <input
-            value={searchKeyword}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setSearchKeyword(e.currentTarget.value)
-            }
-          />
-          {addressData && (
-            <select
-              onChange={(event) => {
-                onChange(event.target.value);
-                setSearchKeyword('');
-              }}
-            >
-              (
-              {addressData.map((address) => {
-                const fullAddress =
-                  address.newAddressList.newAddress[0].fullAddressRoad;
-                const addressName = address.name;
-                return (
-                  <option
-                    key={address.pkey}
-                    value={`${fullAddress} ${addressName}`}
-                  >
-                    {`${fullAddress} ${addressName}`}
-                  </option>
-                );
-              })}
-              )
-            </select>
-          )}
-        </>
+        <Input
+          label={MOGACO_POST.ADDRESS.LABEL}
+          placeholder={MOGACO_POST.ADDRESS.REQUIRED}
+          required
+          value={value}
+          onChange={onChange}
+          errorMessage={error && MOGACO_POST.ADDRESS.REQUIRED}
+          onClick={onClickInput}
+        />
       )}
     />
   );

--- a/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
@@ -1,4 +1,4 @@
-import { Controller, Control } from 'react-hook-form';
+import { Controller, Control, UseFormSetValue } from 'react-hook-form';
 
 import { RequestCreateMogacoDto } from '@morak/apitype';
 
@@ -8,12 +8,18 @@ import { useModal } from '@/hooks';
 
 type PostAddressProps = {
   control: Control<RequestCreateMogacoDto>;
+  setValue: UseFormSetValue<RequestCreateMogacoDto>;
 };
 
-export function PostAddress({ control }: PostAddressProps) {
+export function PostAddress({ control, setValue }: PostAddressProps) {
+  const saveAddress = ({
+    address,
+  }: Pick<RequestCreateMogacoDto, 'address'>) => {
+    setValue('address', address);
+  };
   const { openModal } = useModal();
   const onClickInput = () => {
-    openModal(<MapModal />);
+    openModal(<MapModal saveAddress={saveAddress} />);
   };
 
   return (

--- a/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostAddress.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, useEffect, useState } from 'react';
 import { Controller, Control } from 'react-hook-form';
 
 import { RequestCreateMogacoDto } from '@morak/apitype';
@@ -5,6 +6,7 @@ import { RequestCreateMogacoDto } from '@morak/apitype';
 import { Input, MapModal } from '@/components';
 import { MOGACO_POST } from '@/constants';
 import { useModal } from '@/hooks';
+import { tmap } from '@/services';
 
 type PostAddressProps = {
   control: Control<RequestCreateMogacoDto>;
@@ -15,21 +17,44 @@ export function PostAddress({ control }: PostAddressProps) {
   const onClickInput = () => {
     openModal(<MapModal />);
   };
+  const [searchKeyword, setSearchKeyword] = useState('');
+
+  useEffect(() => {
+    const getAddress = async () => {
+      const data = await tmap.searchAddress(searchKeyword);
+      const addressData = data.searchPoiInfo.pois.poi;
+      // eslint-disable-next-line no-console
+      console.log(addressData);
+    };
+
+    if (searchKeyword) {
+      getAddress();
+    }
+  }, [searchKeyword]);
+
   return (
     <Controller
       control={control}
       name="address"
       rules={{ required: true }}
       render={({ field: { onChange, value }, fieldState: { error } }) => (
-        <Input
-          label={MOGACO_POST.ADDRESS.LABEL}
-          placeholder={MOGACO_POST.ADDRESS.REQUIRED}
-          required
-          onChange={onChange}
-          value={value}
-          errorMessage={error && MOGACO_POST.ADDRESS.REQUIRED}
-          onClick={onClickInput}
-        />
+        <>
+          <Input
+            label={MOGACO_POST.ADDRESS.LABEL}
+            placeholder={MOGACO_POST.ADDRESS.REQUIRED}
+            required
+            onChange={onChange}
+            value={value}
+            errorMessage={error && MOGACO_POST.ADDRESS.REQUIRED}
+            onClick={onClickInput}
+          />
+          <input
+            value={searchKeyword}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setSearchKeyword(e.currentTarget.value)
+            }
+          />
+        </>
       )}
     />
   );

--- a/app/frontend/src/pages/MogacoPost/index.tsx
+++ b/app/frontend/src/pages/MogacoPost/index.tsx
@@ -107,7 +107,7 @@ export function MogacoPostPage() {
           setGroup={setGroup}
         />
         <PostMaxHumanCount control={control} isEdit={!!mogacoData} />
-        <PostAddress control={control} />
+        <PostAddress control={control} setValue={setValue} />
         <PostDate control={control} isEdit={!!mogacoData} />
         <PostContents control={control} />
       </div>

--- a/app/frontend/src/queries/index.ts
+++ b/app/frontend/src/queries/index.ts
@@ -2,5 +2,6 @@ import { mergeQueryKeys } from '@lukemorales/query-key-factory';
 
 import { groupKeys } from './group';
 import { mogacoKeys } from './mogaco';
+import { tmapKeys } from './tmap';
 
-export const queryKeys = mergeQueryKeys(groupKeys, mogacoKeys);
+export const queryKeys = mergeQueryKeys(groupKeys, mogacoKeys, tmapKeys);

--- a/app/frontend/src/queries/tmap.ts
+++ b/app/frontend/src/queries/tmap.ts
@@ -1,0 +1,10 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+import { tmap } from '@/services';
+
+export const tmapKeys = createQueryKeys('tmap', {
+  searchAddress: (filters: { searchKeyword: string }) => ({
+    queryKey: [{ filters }],
+    queryFn: () => tmap.searchAddress(filters),
+  }),
+});

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './group';
 export * from './member';
 export * from './mogaco';
+export * from './tmap';

--- a/app/frontend/src/services/tmap.ts
+++ b/app/frontend/src/services/tmap.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { TMAP_API_KEY } from '@/constants';
+import { TmapResponse } from '@/types';
 
 export const tmap = {
   endPoint: {
@@ -25,7 +26,7 @@ export const tmap = {
     };
     const queryString = new URLSearchParams(searchOptions).toString();
 
-    const { data } = await axios.get(
+    const { data } = await axios.get<TmapResponse>(
       `${tmap.endPoint.pois}?${queryString}`,
       options,
     );

--- a/app/frontend/src/services/tmap.ts
+++ b/app/frontend/src/services/tmap.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+
+import { TMAP_API_KEY } from '@/constants';
+
+export const tmap = {
+  endPoint: {
+    pois: 'https://apis.openapi.sk.com/tmap/pois',
+  },
+
+  searchAddress: async (searchKeyword: string) => {
+    const options = {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        appKey: TMAP_API_KEY,
+      },
+    };
+    const searchOptions = {
+      version: '1',
+      searchKeyword: encodeURI(searchKeyword),
+      searchType: 'all',
+      searchtypCd: 'A',
+      reqCoordType: 'WGS84GEO',
+      resCoordType: 'WGS84GEO',
+      page: '1',
+      count: '20',
+      multiPoint: 'N',
+      poiGroupYn: 'N',
+    };
+    const queryString = new URLSearchParams(searchOptions).toString();
+
+    const { data } = await axios.get(
+      `${tmap.endPoint.pois}?${queryString}`,
+      options,
+    );
+    return data;
+  },
+};

--- a/app/frontend/src/services/tmap.ts
+++ b/app/frontend/src/services/tmap.ts
@@ -7,7 +7,7 @@ export const tmap = {
     pois: 'https://apis.openapi.sk.com/tmap/pois',
   },
 
-  searchAddress: async (searchKeyword: string) => {
+  searchAddress: async ({ searchKeyword }: { searchKeyword: string }) => {
     const options = {
       method: 'GET',
       headers: {
@@ -17,15 +17,11 @@ export const tmap = {
     };
     const searchOptions = {
       version: '1',
-      searchKeyword: encodeURI(searchKeyword),
+      searchKeyword,
       searchType: 'all',
-      searchtypCd: 'A',
-      reqCoordType: 'WGS84GEO',
-      resCoordType: 'WGS84GEO',
+      searchtypCd: 'A', // 검색 결과 정렬 정확도순
       page: '1',
       count: '20',
-      multiPoint: 'N',
-      poiGroupYn: 'N',
     };
     const queryString = new URLSearchParams(searchOptions).toString();
 

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './chatting';
+export * from './tmap';

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -1,0 +1,35 @@
+export type NewAddress = {
+  centerLat: string;
+  centerLon: string;
+  frontLat: string;
+  frontLon: string;
+  fullAddressRoad: string;
+};
+
+export type NewAddressList = {
+  newAddress: NewAddress[];
+};
+
+export type Poi = {
+  newAddressList: NewAddressList;
+  id: string;
+  pkey: string;
+  name: string;
+  noorLat: string;
+  noorLon: string;
+};
+
+export type Pois = {
+  poi: Poi[];
+};
+
+export type SearchPoiInfo = {
+  totalCount: string;
+  count: string;
+  page: string;
+  pois: Pois;
+};
+
+export type TmapResponse = {
+  searchPoiInfo: SearchPoiInfo;
+};


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- #261 
- 장소 검색 시 API 불러오고 그를 사용해 장소 입력하는 부분 1차 구현
- 주소 입력창 클릭 시 맵 모달을 띄워 장소 검색할 수 있도록 합니다. input과 datalist 태그를 사용하여 구현하려고 했으나, 원하는 동작은 주소는 사용자가 직접 입력한 텍스트가 아닌 API 검색 결과를 통한 오직 풀 주소만 입력하게 하고 싶었기 때문에 input과 ul, li 태그를 사용하여 구현하는 방향으로 수정했습니다.
  - 자세한 내용은 [노션](https://www.notion.so/ttaerrim/be56a4fcbd3f4fe9a6f29525b492ab0c?p=1645d224b33d4f968ee81dca843bd8ae&pm=s)에 작성 중
- 컴포넌트가 점점 길어지고 있는데, 컴포넌트 분리는 기능 구현 완료 후 작업할 예정입니다.


## 완료한 기능 명세
- [x] 장소 검색 API 붙이기

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


https://github.com/boostcampwm2023/web17_morak/assets/43867711/05577c97-154f-42bf-978d-6ff14f3f7d90


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

