### PR TITLE
[Modify] 장소 선택 시 지도에서 장소를 직접 선택할 수 있는 기능 추가

### DIFF
--- a/app/frontend/src/components/Map/Marker.tsx
+++ b/app/frontend/src/components/Map/Marker.tsx
@@ -1,7 +1,7 @@
 import ReactDOMServer from 'react-dom/server';
 
 import { ReactComponent as Pin } from '@/assets/icons/pin.svg';
-import { TMap } from '@/types';
+import { TMap, TMapLatLng } from '@/types';
 
 import * as styles from './index.css';
 
@@ -9,19 +9,13 @@ const { Tmapv2 } = window;
 
 type MarkerProps = {
   mapContent: TMap;
-  latitude: number;
-  longitude: number;
+  position: TMapLatLng;
   theme: 'green' | 'red';
 };
 
-export const Marker = ({
-  mapContent,
-  latitude,
-  longitude,
-  theme,
-}: MarkerProps) =>
+export const Marker = ({ mapContent, position, theme }: MarkerProps) =>
   new Tmapv2.Marker({
-    position: new Tmapv2.LatLng(latitude, longitude),
+    position,
     iconHTML: ReactDOMServer.renderToString(
       <Pin className={styles.marker({ theme })} width={50} height={50} />,
     ),

--- a/app/frontend/src/components/Map/index.tsx
+++ b/app/frontend/src/components/Map/index.tsx
@@ -29,7 +29,8 @@ const setMyLocation = (mapContent: MapType) => {
   const onSuccess = (position: Geolocation) => {
     const { latitude, longitude } = position.coords;
     mapContent.setCenter(new Tmapv2.LatLng(latitude, longitude));
-    const marker = Marker({ mapContent, latitude, longitude, theme: 'red' });
+    const mapPosition = new Tmapv2.LatLng(latitude, longitude);
+    const marker = Marker({ mapContent, position: mapPosition, theme: 'red' });
     marker.setLabel(`<span class=${styles.label}>현 위치</span>`);
   };
   navigator.geolocation.getCurrentPosition(onSuccess);
@@ -52,8 +53,7 @@ export function Map({ onClickMarker }: MapProps) {
         const position = new Tmapv2.LatLng(latitude, longitude);
         const marker = Marker({
           mapContent,
-          latitude,
-          longitude,
+          position,
           theme: 'green',
         });
         marker.addListener('click', () => {

--- a/app/frontend/src/components/Modal/MapModal/index.tsx
+++ b/app/frontend/src/components/Modal/MapModal/index.tsx
@@ -27,9 +27,9 @@ export function MapModal({ saveAddress }: MapModalProps) {
   const [open, setOpen] = useModalAtom();
   const [searchKeyword, setSearchKeyword] = useState('');
   const debouncedSearchKeyword = useDebounce(searchKeyword);
-  const [selectedAddress, setSelectedAddress] = useState('');
   const mapRef = useRef<HTMLDivElement>(null);
-  const { coord, setCoord } = useMap(mapRef);
+
+  const { coord, setCoord, currentAddress: selectedAddress } = useMap(mapRef);
 
   const { data: tmapResponse } = useQuery({
     ...queryKeys.tmap.searchAddress({
@@ -62,7 +62,6 @@ export function MapModal({ saveAddress }: MapModalProps) {
   >(
     e: Event,
   ) => {
-    setSelectedAddress(e.currentTarget.getAttribute('value') || '');
     const coordinate = {
       latitude: Number(e.currentTarget.getAttribute('data-lat')),
       longitude: Number(e.currentTarget.getAttribute('data-lon')),

--- a/app/frontend/src/components/Modal/MapModal/index.tsx
+++ b/app/frontend/src/components/Modal/MapModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { RequestCreateMogacoDto } from '@morak/apitype';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
@@ -23,26 +23,13 @@ type MapModalProps = {
   >) => void;
 };
 
-type Coord = {
-  latitude: number | null;
-  longitude: number | null;
-};
-
 export function MapModal({ saveAddress }: MapModalProps) {
   const [open, setOpen] = useModalAtom();
   const [searchKeyword, setSearchKeyword] = useState('');
   const debouncedSearchKeyword = useDebounce(searchKeyword);
   const [selectedAddress, setSelectedAddress] = useState('');
-  const [selectedCoord, setSelectedCoord] = useState<Coord>({
-    latitude: null,
-    longitude: null,
-  });
   const mapRef = useRef<HTMLDivElement>(null);
-  const { updateMarker } = useMap(mapRef);
-
-  useEffect(() => {
-    updateMarker(selectedCoord);
-  }, [selectedCoord, updateMarker]);
+  const { coord, setCoord } = useMap(mapRef);
 
   const { data: tmapResponse } = useQuery({
     ...queryKeys.tmap.searchAddress({
@@ -64,7 +51,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
   };
 
   const onClickConfirm = () => {
-    const { latitude, longitude } = selectedCoord;
+    const { latitude, longitude } = coord;
     if (!(latitude && longitude)) return;
     saveAddress({ address: selectedAddress, latitude, longitude });
     closeModal();
@@ -80,7 +67,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
       latitude: Number(e.currentTarget.getAttribute('data-lat')),
       longitude: Number(e.currentTarget.getAttribute('data-lon')),
     };
-    setSelectedCoord(coordinate);
+    setCoord(coordinate);
   };
 
   return (

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -6,7 +6,7 @@ import {
   MAX_ZOOM_LEVEL,
   MIN_ZOOM_LEVEL,
 } from '@/constants';
-import { TMap, TMapMarker } from '@/types';
+import { TMap, TMapEvent, TMapMarker } from '@/types';
 
 const { Tmapv2 } = window;
 
@@ -33,7 +33,7 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
       return;
     }
 
-    mapInstance.addListener('click', (e) => {
+    const renderMarker = (e: TMapEvent) => {
       const { latLng } = e;
       const position = new Tmapv2.LatLng(latLng.lat(), latLng.lng());
 
@@ -47,7 +47,9 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
       } else {
         currentMarker.setPosition(position);
       }
-    });
+    };
+
+    mapInstance.addListener('click', renderMarker);
   }, [mapInstance, currentMarker]);
 
   const updateMarker = useCallback(

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -61,9 +61,9 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
 
       if (currentMarker) {
         const currMarker = currentMarker.getPosition();
-        const prevLatitude = currMarker.lat();
-        const prevLongitude = currMarker.lng();
-        if (prevLatitude === latitude && prevLongitude === longitude) {
+        const changedLatitude = currMarker.lat() !== latitude;
+        const changedLongitude = currMarker.lng() !== longitude;
+        if (changedLatitude || changedLongitude) {
           return;
         }
       }

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -70,8 +70,7 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
       const position = new Tmapv2.LatLng(latitude, longitude);
       const marker = Marker({
         mapContent: mapInstance,
-        latitude,
-        longitude,
+        position,
         theme: 'green',
       });
       setCurrentMarker(marker);

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -70,7 +70,10 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
   }, [mapInstance, currentCoord]);
 
   const updateMarker = useCallback(
-    (coord: { latitude: number | null; longitude: number | null }) => {
+    (coord: {
+      latitude: number | undefined;
+      longitude: number | undefined;
+    }) => {
       const { latitude, longitude } = coord;
       if (!(latitude && longitude) || !mapInstance) {
         return;
@@ -84,5 +87,14 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
     [mapInstance],
   );
 
-  return { mapInstance, updateMarker };
+  const coord = {
+    latitude: currentCoord?.lat(),
+    longitude: currentCoord?.lng(),
+  };
+
+  const setCoord = (currCoord: { latitude: number; longitude: number }) => {
+    setCurrentCoord(new Tmapv2.LatLng(currCoord.latitude, currCoord.longitude));
+  };
+
+  return { mapInstance, updateMarker, coord, setCoord };
 };

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -33,6 +33,10 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
   });
   const currentAddress = addressData?.addressInfo.fullAddress || '';
 
+  const setCenterToSelectedCoord = (position: TMapLatLng) => {
+    mapInstance?.setCenter(position);
+  };
+
   useEffect(() => {
     if (!currentCoord) {
       return;
@@ -106,7 +110,9 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
   );
 
   const setCoord = (currCoord: { latitude: number; longitude: number }) => {
-    setCurrentCoord(new Tmapv2.LatLng(currCoord.latitude, currCoord.longitude));
+    const position = new Tmapv2.LatLng(currCoord.latitude, currCoord.longitude);
+    setCurrentCoord(position);
+    setCenterToSelectedCoord(position);
   };
 
   return {

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -58,8 +58,9 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
       }
 
       if (currentMarker) {
-        const { _lat: prevLatitude, _lng: prevLongitude } =
-          currentMarker.getPosition();
+        const currMarker = currentMarker.getPosition();
+        const prevLatitude = currMarker.lat();
+        const prevLongitude = currMarker.lng();
         if (prevLatitude === latitude && prevLongitude === longitude) {
           return;
         }

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -113,5 +113,11 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
     setCurrentCoord(new Tmapv2.LatLng(currCoord.latitude, currCoord.longitude));
   };
 
-  return { mapInstance, updateMarker, coord, setCoord, currentAddress };
+  return {
+    mapInstance,
+    updateMarker,
+    coord,
+    setCoord,
+    currentAddress,
+  };
 };

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { Marker } from '@/components/Map/Marker';
 import {
@@ -29,6 +29,7 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
       longitude: coord.longitude,
     }),
     enabled: coord.latitude !== 0 && coord.longitude !== 0,
+    placeholderData: keepPreviousData,
   });
   const currentAddress = addressData?.addressInfo.fullAddress || '';
 

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -28,6 +28,28 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
     setMapInstance(map);
   }, [mapRef, mapInstance]);
 
+  useEffect(() => {
+    if (!mapInstance) {
+      return;
+    }
+
+    mapInstance.addListener('click', (e) => {
+      const { latLng } = e;
+      const position = new Tmapv2.LatLng(latLng.lat(), latLng.lng());
+
+      if (!currentMarker) {
+        const marker = Marker({
+          mapContent: mapInstance,
+          position,
+          theme: 'green',
+        });
+        setCurrentMarker(marker);
+      } else {
+        currentMarker.setPosition(position);
+      }
+    });
+  }, [mapInstance, currentMarker]);
+
   const updateMarker = useCallback(
     (coord: { latitude: number | null; longitude: number | null }) => {
       const { latitude, longitude } = coord;

--- a/app/frontend/src/components/Modal/MapModal/useMap.ts
+++ b/app/frontend/src/components/Modal/MapModal/useMap.ts
@@ -63,7 +63,7 @@ export const useMap = (mapRef: React.RefObject<HTMLDivElement>) => {
         const currMarker = currentMarker.getPosition();
         const changedLatitude = currMarker.lat() !== latitude;
         const changedLongitude = currMarker.lng() !== longitude;
-        if (changedLatitude || changedLongitude) {
+        if (!(changedLatitude || changedLongitude)) {
           return;
         }
       }

--- a/app/frontend/src/queries/tmap.ts
+++ b/app/frontend/src/queries/tmap.ts
@@ -7,4 +7,8 @@ export const tmapKeys = createQueryKeys('tmap', {
     queryKey: [{ filters }],
     queryFn: () => tmap.searchAddress(filters),
   }),
+  getAddressFromCoord: (filters: { latitude: number; longitude: number }) => ({
+    queryKey: [{ filters }],
+    queryFn: () => tmap.getAddressFromCoord(filters),
+  }),
 });

--- a/app/frontend/src/services/tmap.ts
+++ b/app/frontend/src/services/tmap.ts
@@ -4,9 +4,10 @@ import { TMAP_API_KEY } from '@/constants';
 import { TmapResponse, TmapReverseGeocodingResponse } from '@/types';
 
 export const tmap = {
+  host: 'https://apis.openapi.sk.com/tmap',
   endPoint: {
-    pois: 'https://apis.openapi.sk.com/tmap/pois',
-    reverseGeocoding: 'https://apis.openapi.sk.com/tmap/geo/reversegeocoding',
+    pois: '/pois',
+    reverseGeocoding: '/geo/reversegeocoding',
   },
 
   searchAddress: async ({ searchKeyword }: { searchKeyword: string }) => {
@@ -28,7 +29,7 @@ export const tmap = {
     const queryString = new URLSearchParams(searchOptions).toString();
 
     const { data } = await axios.get<TmapResponse>(
-      `${tmap.endPoint.pois}?${queryString}`,
+      `${tmap.host}${tmap.endPoint.pois}?${queryString}`,
       options,
     );
     return data;
@@ -57,7 +58,7 @@ export const tmap = {
     const queryString = new URLSearchParams(searchOptions).toString();
 
     const { data } = await axios.get<TmapReverseGeocodingResponse>(
-      `${tmap.endPoint.reverseGeocoding}?${queryString}`,
+      `${tmap.host}${tmap.endPoint.reverseGeocoding}?${queryString}`,
       options,
     );
     return data;

--- a/app/frontend/src/services/tmap.ts
+++ b/app/frontend/src/services/tmap.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 
 import { TMAP_API_KEY } from '@/constants';
-import { TmapResponse } from '@/types';
+import { TmapResponse, TmapReverseGeocodingResponse } from '@/types';
 
 export const tmap = {
   endPoint: {
     pois: 'https://apis.openapi.sk.com/tmap/pois',
+    reverseGeocoding: 'https://apis.openapi.sk.com/tmap/geo/reversegeocoding',
   },
 
   searchAddress: async ({ searchKeyword }: { searchKeyword: string }) => {
@@ -28,6 +29,35 @@ export const tmap = {
 
     const { data } = await axios.get<TmapResponse>(
       `${tmap.endPoint.pois}?${queryString}`,
+      options,
+    );
+    return data;
+  },
+
+  getAddressFromCoord: async ({
+    latitude,
+    longitude,
+  }: {
+    latitude: number;
+    longitude: number;
+  }) => {
+    const options = {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        appKey: TMAP_API_KEY,
+      },
+    };
+    const searchOptions = {
+      version: '1',
+      lat: latitude.toString(),
+      lon: longitude.toString(),
+      addressType: 'A04', // 새 주소
+    };
+    const queryString = new URLSearchParams(searchOptions).toString();
+
+    const { data } = await axios.get<TmapReverseGeocodingResponse>(
+      `${tmap.endPoint.reverseGeocoding}?${queryString}`,
       options,
     );
     return data;

--- a/app/frontend/src/types/global.d.ts
+++ b/app/frontend/src/types/global.d.ts
@@ -1,4 +1,4 @@
-import { LatLng, TMap, TMapSize } from './tmap';
+import { TMapLatLng, TMap, TMapSize } from './tmap';
 
 declare global {
   interface Window {
@@ -6,7 +6,7 @@ declare global {
       Map: new (
         element: HTMLElement | string,
         options?: {
-          center?: LatLng;
+          center?: TMapLatLng;
           scaleBar?: boolean;
           width?: string | number;
           height?: string | number;
@@ -14,10 +14,10 @@ declare global {
           zoomControl?: boolean;
         },
       ) => TMap;
-      LatLng: new (lat, lon) => LatLng;
+      LatLng: new (lat, lon) => TMapLatLng;
       Marker: new (options?: {
         map: TMap;
-        position: LatLng;
+        position: TMapLatLng;
         iconHTML?: string;
         iconSize?: TMapSize;
       }) => TMapMarker;

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -57,6 +57,27 @@ export type TMapSize = {
   _width: number;
   _height: number;
 };
+export type TmapAddressInfo = {
+  fullAddress: string;
+  addressType: string;
+  city_do: string;
+  gu_gun: string;
+  eup_myun: string;
+  adminDong: string;
+  adminDongCode: string;
+  legalDong: string;
+  legalDongCode: string;
+  ri: string;
+  bunji: string;
+  roadName: string;
+  buildingIndex: string;
+  buildingName: string;
+  mappingDistance: string;
+  roadCode: string;
+};
 export type TmapResponse = {
   searchPoiInfo: SearchPoiInfo;
+};
+export type TmapReverseGeocodingResponse = {
+  addressInfo: TmapAddressInfo;
 };

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -59,21 +59,6 @@ export type TMapSize = {
 };
 export type TmapAddressInfo = {
   fullAddress: string;
-  addressType: string;
-  city_do: string;
-  gu_gun: string;
-  eup_myun: string;
-  adminDong: string;
-  adminDongCode: string;
-  legalDong: string;
-  legalDongCode: string;
-  ri: string;
-  bunji: string;
-  roadName: string;
-  buildingIndex: string;
-  buildingName: string;
-  mappingDistance: string;
-  roadCode: string;
 };
 export type TmapResponse = {
   searchPoiInfo: SearchPoiInfo;

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -1,8 +1,3 @@
-export type LatLng = {
-  _lat: number;
-  _lng: number;
-};
-
 export type NewAddress = {
   centerLat: string;
   centerLon: string;
@@ -34,14 +29,29 @@ export type SearchPoiInfo = {
   page: string;
   pois: Pois;
 };
+
 export type TMap = {
-  setCenter: (latLng: LatLng) => void;
+  setCenter: (latLng: TMapLatLng) => void;
   setZoomLimit: (minZoom: number, maxZoom: number) => void;
   destroy: () => void;
+  addListener: (
+    eventType: EventType,
+    listener: (event: TMapEvent) => void,
+  ) => void;
 };
+type EventType = 'click';
+export type TMapEvent = {
+  latLng: TMapLatLng;
+};
+export type TMapLatLng = {
+  lat: () => number;
+  lng: () => number;
+};
+
 export type TMapMarker = {
   setMap: (map: TMap | null) => void;
-  getPosition: () => LatLng;
+  getPosition: () => TMapLatLng;
+  setPosition: (latLng: TMapLatLng) => void;
 };
 export type TMapSize = {
   _width: number;


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- #261 
- 사용자가 직접 지도를 클릭해 위치를 선택하는 기능 구현
- 좌표를 주소로 변환해 주는 TMap API(reverseGeocoding) 사용
- Marker 컴포넌트를 new Tmapv2.marker 메소드의 parameter와 동일하게 사용할 수 있도록 latitude/longitude → position으로 변경했습니다. @LEEJW1953 
- 지도 클릭 시 마커를 띄우며 고민했던 사항은 [노션](https://www.notion.so/ttaerrim/TMAP-API-1645d224b33d4f968ee81dca843bd8ae?pvs=4#b13220ed7188418ba00b3f88c8eade26)에 정리해 두었으니 참고바랍니다. (마커 여러 개 찍히는 문제, 장소/지도 클릭 시 생기는 마커 문제, 좌표가 변경될 때마다 장소 렌더링 관련 문제)

## 완료한 기능 명세
- [x] 지도 클릭 시 선택한 곳의 장소 선택할 수 있도록 구현 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


https://github.com/boostcampwm2023/web17_morak/assets/43867711/936396d7-1504-43f8-a17f-ab26fac3f6f5


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

