### PR TITLE
[Feat] 가입 그룹에 대한 모각코 조회 처리

### DIFF
--- a/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
@@ -23,9 +23,9 @@ export class MogacoController {
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [MogacoDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiQuery({ name: 'date', description: 'Optional. Format: YYYY-MM or YYYY-MM-DD', required: false })
-  async getMogaco(@Query('date') date?: string, @GetUser() member?: Member): Promise<MogacoDto[]> {
+  async getMogaco(@GetUser() member: Member, @Query('date') date?: string): Promise<MogacoDto[]> {
     if (date) {
-      return this.mogacoService.getMogacoByDate(date);
+      return this.mogacoService.getMogacoByDate(date, member);
     } else {
       return this.mogacoService.getAllMogaco(member);
     }

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -51,7 +51,14 @@ export class MogacoRepository {
     }));
   }
 
-  async getMogacoByDate(date: string): Promise<MogacoDto[]> {
+  async getMogacoByDate(date: string, member: Member): Promise<MogacoDto[]> {
+    const userGroups = await this.prisma.groupToUser.findMany({
+      where: { userId: member.id },
+      select: { groupId: true },
+    });
+
+    const userGroupIds = userGroups.map((group) => group.groupId);
+
     let startDate: Date;
     let endDate: Date;
 
@@ -67,6 +74,10 @@ export class MogacoRepository {
 
     const mogacos = await this.prisma.mogaco.findMany({
       where: {
+        deletedAt: null,
+        groupId: {
+          in: userGroupIds,
+        },
         date: {
           gte: startDate,
           lte: endDate,

--- a/app/backend/src/mogaco-boards/mogaco-boards.service.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.service.ts
@@ -13,8 +13,8 @@ export class MogacoService {
     return this.mogacoRepository.getAllMogaco(member);
   }
 
-  async getMogacoByDate(date: string): Promise<MogacoDto[]> {
-    return this.mogacoRepository.getMogacoByDate(date);
+  async getMogacoByDate(date: string, member: Member): Promise<MogacoDto[]> {
+    return this.mogacoRepository.getMogacoByDate(date, member);
   }
 
   async getMogacoById(id: number, member: Member): Promise<MogacoWithMemberDto> {


### PR DESCRIPTION
## 설명
- close #281 

사용자는 본인이 가입한 그룹에 대한 모각코 조회만 가능해야합니다.
특정 게시글을 조회하는 경우 url로 접근이 가능하기 때문에 이를 처리하기 위해
가입한 그룹의 모각코가 아닌 특정 게시글을 접근하려고 할 시 Forbidden으로 차단합니다.

## 완료한 기능 명세
- [x] 가입 그룹에 대한 모각코 조회 처리
- [x] 특정 게시글 조회 시 가입 그룹이 아닐 시 차단
- [x] 기간별 조회 시 가입 그룹에 대한 모각코만 조회 처리

### 스크린샷

[가입 그룹에 따른 모각코 게시글 조회 처리](https://ttaerrim.notion.site/64ea715b499e4adc820e92f4cc425f08?pvs=4)
[특정 게시물 조회 시 가입 그룹의 게시글이 아닐 시 오류 처리](https://ttaerrim.notion.site/dcb6f1e0c0e047ed8a243c2aef7259b7?pvs=4)
[기간별 조회 시](https://ttaerrim.notion.site/4a99b8bb8f374e868ba856c261f85342?pvs=4)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

