### PR TITLE
[Bug] 맵 모달에서 엔터 누르면 모달만 닫히는 버그 픽스

### DIFF
--- a/app/frontend/src/components/Modal/MapModal/index.tsx
+++ b/app/frontend/src/components/Modal/MapModal/index.tsx
@@ -71,7 +71,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
 
   return (
     <dialog className={styles.container} open={open}>
-      <form method="dialog" className={styles.form}>
+      <div className={styles.form}>
         <div className={styles.currentAddress}>
           <span className={sansRegular14}>선택한 주소: </span>
           <span className={sansBold14}>{selectedAddress}</span>
@@ -137,7 +137,7 @@ export function MapModal({ saveAddress }: MapModalProps) {
             확인
           </Button>
         </div>
-      </form>
+      </div>
     </dialog>
   );
 }


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- #297 
- dialog 내 `<form method='dialog'>`를 사용하면 엔터 키를 눌렀을 때 cancleEvent가 동작하면서 모달이 닫히는 현상이 발생합니다. 현재 모달의 백그라운드를 ::backdrop 속성이 아닌 div를 사용하고 있어 modalOpenedAtom의 상태에 의해 백그라운드가 표시되는데, 엔터를 눌렀을 경우는 modalOpenedAtom 상태를 조정하는 것이 아닌 단순 modal의 open 상태만 변경되어 발생하는 버그입니다. 임시로 form 태그를 div 태그로 변경하여 엔터 키를 눌렀을 때도 모달이 닫히지 않도록 처리했습니다.

## 완료한 기능 명세
- [x] 맵 모달에서 엔터 누르면 모달만 닫히는 버그 픽스

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

