### PR TITLE
[Fix] 채팅 서버에 현재 사용자의 provider_id 대신 id를 전달하도록 변경

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
@@ -59,7 +59,7 @@ export function ChatList({
       <div ref={observableRef} />
       {chatItems.map((chatItem) => {
         const participantInfo = participants.find(
-          (participant) => participant.providerId === chatItem.user,
+          (participant) => participant.id === chatItem.user,
         );
         return (
           <MemorizedTalkItem

--- a/app/frontend/src/components/Sidebar/Wrapper/ChattingSidebar/index.tsx
+++ b/app/frontend/src/components/Sidebar/Wrapper/ChattingSidebar/index.tsx
@@ -20,9 +20,9 @@ export function ChattingSidebar({
   title,
   participants,
 }: ChattingSidebarProps) {
-  const { data: currentUser } = useGetMyInfoQuery();
+  const { data } = useGetMyInfoQuery();
 
-  if (!currentUser) {
+  if (!data) {
     return (
       <Sidebar closed={closed} toggleClosed={toggleClosed}>
         <Error message="로그인 필요" />
@@ -30,11 +30,10 @@ export function ChattingSidebar({
     );
   }
 
-  if (
-    !participants.find(
-      (participant) => participant.providerId === currentUser.providerId,
-    )
-  ) {
+  const currentUser = participants.find(
+    (participant) => participant.providerId === data.providerId,
+  );
+  if (!currentUser) {
     return (
       <Sidebar closed={closed} toggleClosed={toggleClosed}>
         <div className={styles.notParticipated}>
@@ -52,7 +51,7 @@ export function ChattingSidebar({
         postId={id}
         title={title}
         participants={participants}
-        currentUserId={currentUser.providerId}
+        currentUserId={currentUser.id}
       />
     </Sidebar>
   );

--- a/app/frontend/src/pages/MogacoDetail/index.tsx
+++ b/app/frontend/src/pages/MogacoDetail/index.tsx
@@ -14,9 +14,10 @@ import * as styles from './index.css';
 export function MogacoDetailPage() {
   const { id } = useParams();
   const [chattingClosed, setChattingClosed] = useState(true);
-  const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery(
-    queryKeys.mogaco.detail(id!),
-  );
+  const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery({
+    ...queryKeys.mogaco.detail(id!),
+    enabled: !!id,
+  });
 
   const toggleChatting = () => setChattingClosed(!chattingClosed);
   const openChatting = () => setChattingClosed(false);
@@ -31,7 +32,7 @@ export function MogacoDetailPage() {
     );
   }
 
-  if (!mogacoData) {
+  if (!mogacoData || !id) {
     return (
       <div className={styles.wrapper}>
         <div className={styles.container}>
@@ -51,9 +52,9 @@ export function MogacoDetailPage() {
         participants={mogacoData.participants}
       />
       <div className={styles.container}>
-        <DetailHeader id={id!} openChatting={openChatting} />
+        <DetailHeader id={id} openChatting={openChatting} />
         <DetailInfo
-          id={id!}
+          id={id}
           latitude={mogacoData.latitude}
           longitude={mogacoData.longitude}
         />


### PR DESCRIPTION
## 설명
- close #314
- 채팅 서버에 사용자의 provider_id 대신 id를 전달하도록 변경합니다.

## 완료한 기능 명세
- [x] 현재 사용자의 id를 참여자 목록으로부터 찾기
- [x]  provider_id 대신 id를 전달

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

