### PR TITLE
[Feat] 비로그인 시 메인 외 다른 라우터에 접근 방지

### DIFF
--- a/app/frontend/src/components/Auth/index.tsx
+++ b/app/frontend/src/components/Auth/index.tsx
@@ -1,10 +1,26 @@
-import { ReactNode } from 'react';
+import { ReactNode, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { getCookies } from '@/utils';
 
 type AuthProps = {
   children: ReactNode;
 };
 
 export function AuthRequired({ children }: AuthProps) {
+  const accessToken = getCookies('access_token');
+
+  const navigate = useNavigate();
+  const redirectToMain = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      redirectToMain();
+    }
+  }, [accessToken, redirectToMain]);
+
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;
 }

--- a/app/frontend/src/components/Auth/index.tsx
+++ b/app/frontend/src/components/Auth/index.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+type AuthProps = {
+  children: ReactNode;
+};
+
+export function AuthRequired({ children }: AuthProps) {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
+}

--- a/app/frontend/src/components/Header/index.css.ts
+++ b/app/frontend/src/components/Header/index.css.ts
@@ -2,6 +2,8 @@ import { style } from '@vanilla-extract/css';
 
 import { vars, fontStyle } from '@/styles';
 
+const { grayscaleWhite, grayscale100, grayscale200, morakGreen } = vars.color;
+
 export const active = style({});
 
 export const container = style({
@@ -12,8 +14,8 @@ export const container = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  background: vars.color.grayscaleWhite,
-  borderBottom: `1px solid ${vars.color.grayscale100}`,
+  background: grayscaleWhite,
+  borderBottom: `1px solid ${grayscale100}`,
   zIndex: 20,
 });
 
@@ -46,11 +48,11 @@ export const logoTitle = style([
 ]);
 
 export const profileButton = style({
-  fill: vars.color.grayscale200,
+  fill: grayscale200,
 
   selectors: {
     [`${active} &`]: {
-      fill: vars.color.morakGreen,
+      fill: morakGreen,
     },
   },
 });
@@ -65,12 +67,12 @@ export const sideMenu = style({
 export const sideMenuButton = style([
   fontStyle.sansRegular18,
   {
-    color: vars.color.grayscale200,
+    color: grayscale200,
     cursor: 'pointer',
     selectors: {
       [`${active}&`]: {
         fontWeight: 700,
-        color: vars.color.morakGreen,
+        color: morakGreen,
       },
     },
   },
@@ -80,6 +82,6 @@ export const title = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.4rem',
-  color: vars.color.morakGreen,
+  color: morakGreen,
   textAlign: 'center',
 });

--- a/app/frontend/src/components/Header/index.css.ts
+++ b/app/frontend/src/components/Header/index.css.ts
@@ -66,13 +66,13 @@ export const sideMenuButton = style([
   fontStyle.sansRegular18,
   {
     color: vars.color.grayscale200,
-  },
-]);
-
-export const sideMenuButtonActive = style([
-  fontStyle.sansBold18,
-  {
-    color: vars.color.morakGreen,
+    cursor: 'pointer',
+    selectors: {
+      [`${active}&`]: {
+        fontWeight: 700,
+        color: vars.color.morakGreen,
+      },
+    },
   },
 ]);
 

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -1,18 +1,16 @@
-import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
 import { ReactComponent as Logo } from '@/assets/icons/morak.svg';
 
 import * as styles from './index.css';
+import { useClickMenu } from './useClickMenu';
 import { useMenu } from './useMenu';
 
 export function Header() {
   const { SIDE_MENU } = useMenu();
   const { pathname } = useLocation();
-  const navigate = useNavigate();
 
-  const onClickMenu = (path: string) => {
-    navigate(`/${path}`);
-  };
+  const { onClickMenu } = useClickMenu();
 
   return (
     <div className={styles.container}>

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -19,10 +19,10 @@ export function Header() {
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
-        <li className={styles.sideMenu}>
+        <ul className={styles.sideMenu}>
           {SIDE_MENU.map((menu) => (
-            <ul
-              role="menu"
+            <li
+              role="menuitem"
               key={menu.pathname}
               onClick={() => onClickMenu(menu.pathname)}
               onKeyDown={() => onClickMenu(menu.pathname)}
@@ -31,9 +31,9 @@ export function Header() {
               }`}
             >
               {menu.value}
-            </ul>
+            </li>
           ))}
-        </li>
+        </ul>
       </div>
     </div>
   );

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -1,12 +1,19 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 import { ReactComponent as Logo } from '@/assets/icons/morak.svg';
-import { ReactComponent as Profile } from '@/assets/icons/profile.svg';
-import { SIDE_MENU } from '@/constants';
 
 import * as styles from './index.css';
+import { useMenu } from './useMenu';
 
 export function Header() {
+  const { SIDE_MENU } = useMenu();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  const onClickMenu = (path: string) => {
+    navigate(`/${path}`);
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -14,25 +21,21 @@ export function Header() {
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
-        <div className={styles.sideMenu}>
-          {SIDE_MENU.map((menu: string) => (
-            <NavLink
-              key={menu}
-              to={`/${menu}`}
-              className={({ isActive }) =>
-                isActive ? styles.sideMenuButtonActive : styles.sideMenuButton
-              }
+        <li className={styles.sideMenu}>
+          {SIDE_MENU.map((menu) => (
+            <ul
+              role="menu"
+              key={menu.pathname}
+              onClick={() => onClickMenu(menu.pathname)}
+              onKeyDown={() => onClickMenu(menu.pathname)}
+              className={`${styles.sideMenuButton} ${
+                pathname === `/${menu.pathname}` ? styles.active : ''
+              }`}
             >
-              {menu}
-            </NavLink>
+              {menu.value}
+            </ul>
           ))}
-          <NavLink
-            to="/profile"
-            className={({ isActive }) => (isActive ? styles.active : '')}
-          >
-            <Profile width={24} height={24} className={styles.profileButton} />
-          </NavLink>
-        </div>
+        </li>
       </div>
     </div>
   );

--- a/app/frontend/src/components/Header/useClickMenu.ts
+++ b/app/frontend/src/components/Header/useClickMenu.ts
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom';
+
+import { getCookies } from '@/utils';
+
+import { useLoginRequireModal } from './useLoginRequireModal';
+
+export const useClickMenu = () => {
+  const navigate = useNavigate();
+  const { openLoginRequireModal } = useLoginRequireModal();
+  const isLogin = getCookies('access_token');
+
+  const onClickMenu = (path: string) => {
+    if (!isLogin) {
+      openLoginRequireModal();
+    } else {
+      navigate(`/${path}`);
+    }
+  };
+
+  return { onClickMenu };
+};

--- a/app/frontend/src/components/Header/useLoginRequireModal.tsx
+++ b/app/frontend/src/components/Header/useLoginRequireModal.tsx
@@ -1,0 +1,12 @@
+import { useModal } from '@/hooks';
+
+import { Modal } from '../Modal';
+
+export const useLoginRequireModal = () => {
+  const { openModal } = useModal();
+  const openLoginRequireModal = () => {
+    openModal(<Modal title="로그인이 필요합니다" buttonType="single" />);
+  };
+
+  return { openLoginRequireModal };
+};

--- a/app/frontend/src/components/Header/useMenu.tsx
+++ b/app/frontend/src/components/Header/useMenu.tsx
@@ -1,0 +1,19 @@
+import { ReactComponent as Profile } from '@/assets/icons/profile.svg';
+
+import * as styles from './index.css';
+
+export const useMenu = () => {
+  const SIDE_MENU = [
+    { pathname: 'mogaco', value: 'mogaco' },
+    { pathname: 'calendar', value: 'calendar' },
+    { pathname: 'map', value: 'map' },
+    {
+      pathname: 'profile',
+      value: (
+        <Profile width={24} height={24} className={styles.profileButton} />
+      ),
+    },
+  ];
+
+  return { SIDE_MENU };
+};

--- a/app/frontend/src/components/Modal/index.tsx
+++ b/app/frontend/src/components/Modal/index.tsx
@@ -10,7 +10,7 @@ type ModalProps = {
   buttonType: 'single' | 'double';
   confirmButtonText?: string;
   cancelButtonText?: string;
-  onClickConfirm: () => void;
+  onClickConfirm?: () => void;
 };
 
 export function Modal({

--- a/app/frontend/src/components/index.ts
+++ b/app/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Auth';
 export * from './Button';
 export * from './Divider';
 export * from './Error';

--- a/app/frontend/src/constants/Header.ts
+++ b/app/frontend/src/constants/Header.ts
@@ -1,1 +1,0 @@
-export const SIDE_MENU = ['mogaco', 'calendar', 'map'];

--- a/app/frontend/src/constants/index.ts
+++ b/app/frontend/src/constants/index.ts
@@ -1,4 +1,3 @@
-export * from './Header';
 export * from './Main';
 export * from './Map';
 export * from './MogacoPost';

--- a/app/frontend/src/hooks/useRouter.tsx
+++ b/app/frontend/src/hooks/useRouter.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 
-import { Layout } from '@/components';
+import { AuthRequired, Layout } from '@/components';
 import {
   MainPage,
   MogacoPage,
@@ -17,8 +17,16 @@ export const useRouter = () =>
     {
       path: '/',
       element: <Layout />,
+      children: [{ index: true, element: <MainPage /> }],
+    },
+    {
+      path: '/',
+      element: (
+        <AuthRequired>
+          <Layout />
+        </AuthRequired>
+      ),
       children: [
-        { index: true, element: <MainPage /> },
         {
           path: 'mogaco',
           element: <MogacoPage />,
@@ -44,6 +52,10 @@ export const useRouter = () =>
     },
     {
       path: '/map',
-      element: <MapLayout />,
+      element: (
+        <AuthRequired>
+          <MapLayout />
+        </AuthRequired>
+      ),
     },
   ]);


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #317 
- 비로그인 시 다른 라우터에 접근하는 것을 막음
  - AuthRequired 컴포넌트를 추가하여 사용했습니다. 
- 헤더 변경 사항 @LEEJW1953 
  - NavLink 대신 onClick 핸들러를 사용해야 하여, ul 태그로 변경했습니다.
  - 헤더 스타일 파일을 리팩토링했습니다. 
    - sideMenuButton active를 selector를 사용하도록 변경
    - vars.color 구조 분해 할당으로 사용
  - 헤더의 constants를 useMenu 훅으로 사용하도록 변경 (프로필까지 map 고차 함수 사용을 위함)

## 완료한 기능 명세
- [x] 비로그인 시 다른 라우터에 접근하는 것을 막음

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


로그인 시 

https://github.com/boostcampwm2023/web17_morak/assets/43867711/466d7888-b76d-403c-a902-9a9a37a725e3

비로그인 시 

https://github.com/boostcampwm2023/web17_morak/assets/43867711/21d9b1b0-3b1d-4cfc-98da-79eb6363b25b


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

