### PR TITLE
[Feat] 현재 로그인한 사용자 정보를 프로필에 표시, 로그아웃 버튼 구현

### DIFF
--- a/app/frontend/src/pages/Profile/MyProfile/index.css.ts
+++ b/app/frontend/src/pages/Profile/MyProfile/index.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles';
+import { sansRegular18 } from '@/styles/font.css';
+
+import * as parentStyle from '../index.css';
+
+export const logoutButton = style({
+  alignSelf: 'end',
+});
+
+export const userInfoBody = style([
+  sansRegular18,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.6rem',
+  },
+]);
+
+export const userInfoLine = style({
+  display: 'flex',
+  gap: '2.4rem',
+});
+
+export const userInfoLineTitle = style({
+  color: vars.color.grayscale200,
+});
+
+export const { section } = parentStyle;

--- a/app/frontend/src/pages/Profile/MyProfile/index.tsx
+++ b/app/frontend/src/pages/Profile/MyProfile/index.tsx
@@ -1,0 +1,50 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { Button, Error } from '@/components';
+import { useGetMyInfoQuery } from '@/queries/hooks';
+import { auth } from '@/services';
+import { sansBold36 } from '@/styles/font.css';
+
+import * as styles from './index.css';
+
+export function MyProfile() {
+  const { data: currentUser } = useGetMyInfoQuery();
+  const { mutateAsync: logoutMutate } = useMutation({
+    mutationFn: (providerId: string) => auth.logout({ providerId }),
+  });
+
+  if (!currentUser) {
+    return <Error message="사용자 정보를 불러오지 못했습니다." />;
+  }
+
+  const { email, nickname } = currentUser;
+  const onLogout = () => {
+    logoutMutate(currentUser.providerId);
+    window.location.href = '/';
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={sansBold36}>내 프로필</div>
+      <div className={styles.userInfoBody}>
+        <div className={styles.userInfoLine}>
+          <span className={styles.userInfoLineTitle}>이메일</span>
+          <span>{email}</span>
+        </div>
+        <div className={styles.userInfoLine}>
+          <span className={styles.userInfoLineTitle}>닉네임</span>
+          <span>{nickname}</span>
+        </div>
+        <Button
+          theme="primary"
+          shape="text"
+          size="large"
+          className={styles.logoutButton}
+          onClick={onLogout}
+        >
+          로그아웃
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/app/frontend/src/pages/Profile/MyProfile/index.tsx
+++ b/app/frontend/src/pages/Profile/MyProfile/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { Button, Error } from '@/components';
+import { Button, Error, Loading } from '@/components';
 import { useGetMyInfoQuery } from '@/queries/hooks';
 import { auth } from '@/services';
 import { sansBold36 } from '@/styles/font.css';
@@ -8,10 +8,14 @@ import { sansBold36 } from '@/styles/font.css';
 import * as styles from './index.css';
 
 export function MyProfile() {
-  const { data: currentUser } = useGetMyInfoQuery();
+  const { isLoading, data: currentUser } = useGetMyInfoQuery();
   const { mutateAsync: logoutMutate } = useMutation({
     mutationFn: (providerId: string) => auth.logout({ providerId }),
   });
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   if (!currentUser) {
     return <Error message="사용자 정보를 불러오지 못했습니다." />;

--- a/app/frontend/src/pages/Profile/MyProfile/index.tsx
+++ b/app/frontend/src/pages/Profile/MyProfile/index.tsx
@@ -9,7 +9,7 @@ import * as styles from './index.css';
 
 export function MyProfile() {
   const { isLoading, data: currentUser } = useGetMyInfoQuery();
-  const { mutateAsync: logoutMutate } = useMutation({
+  const { mutate: logout } = useMutation({
     mutationFn: (providerId: string) => auth.logout({ providerId }),
   });
 
@@ -23,7 +23,7 @@ export function MyProfile() {
 
   const { email, nickname } = currentUser;
   const onLogout = () => {
-    logoutMutate(currentUser.providerId);
+    logout(currentUser.providerId);
     window.location.href = '/';
   };
 

--- a/app/frontend/src/pages/Profile/index.css.ts
+++ b/app/frontend/src/pages/Profile/index.css.ts
@@ -1,8 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-import { vars } from '@/styles';
-import { sansRegular18 } from '@/styles/font.css';
-
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,30 +16,8 @@ export const list = style({
   overflowY: 'auto',
 });
 
-export const logoutButton = style({
-  alignSelf: 'end',
-});
-
 export const section = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '2.4rem',
-});
-
-export const userInfoBody = style([
-  sansRegular18,
-  {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.6rem',
-  },
-]);
-
-export const userInfoLine = style({
-  display: 'flex',
-  gap: '2.4rem',
-});
-
-export const userInfoLineTitle = style({
-  color: vars.color.grayscale200,
 });

--- a/app/frontend/src/pages/Profile/index.tsx
+++ b/app/frontend/src/pages/Profile/index.tsx
@@ -1,33 +1,14 @@
-import { Button, Divider } from '@/components';
-import { sansBold24, sansBold36 } from '@/styles/font.css';
+import { Divider } from '@/components';
+import { sansBold24 } from '@/styles/font.css';
 
 import * as styles from './index.css';
 import { MyGroup } from './MyGroup';
+import { MyProfile } from './MyProfile';
 
 export function ProfilePage() {
   return (
     <div className={styles.container}>
-      <section className={styles.section}>
-        <div className={sansBold36}>내 프로필</div>
-        <div className={styles.userInfoBody}>
-          <div className={styles.userInfoLine}>
-            <span className={styles.userInfoLineTitle}>이메일</span>
-            <span>js43og@gmail.com</span>
-          </div>
-          <div className={styles.userInfoLine}>
-            <span className={styles.userInfoLineTitle}>닉네임</span>
-            <span>지승</span>
-          </div>
-          <Button
-            theme="primary"
-            shape="text"
-            size="large"
-            className={styles.logoutButton}
-          >
-            로그아웃
-          </Button>
-        </div>
-      </section>
+      <MyProfile />
       <Divider />
       <section className={styles.section}>
         <div className={sansBold24}>현재 참가한 모각코</div>

--- a/app/frontend/src/services/auth.ts
+++ b/app/frontend/src/services/auth.ts
@@ -1,0 +1,13 @@
+import { RequestLogoutUserDto } from '@morak/apitype';
+
+import { morakAPI } from './morakAPI';
+
+export const auth = {
+  endPoint: {
+    default: '/auth',
+    logout: '/auth/logout',
+  },
+
+  logout: async (data: RequestLogoutUserDto) =>
+    morakAPI.post(auth.endPoint.logout, data),
+};

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,3 +1,4 @@
+export * from './auth';
 export * from './group';
 export * from './member';
 export * from './mogaco';


### PR DESCRIPTION
## 설명
- close #319
- 현재 로그인한 사용자의 정보를 불러와서 프로필 영역에 표시합니다.
- services/auth.ts 및 logout 코드를 추가하였습니다.
- https://github.com/boostcampwm2023/web17_morak/pull/316 해당 PR 먼저 머지 후 PR 오픈하겠습니다. (종속됨)

## 완료한 기능 명세
- [x] 현재 로그인한 사용자의 정보를 프로필 영역에 표시
- [x] 로그아웃 버튼 구현

### 동작 화면
https://github.com/boostcampwm2023/web17_morak/assets/50646827/cc54e7c8-5783-4102-949a-59844d845304

## 리뷰 요청 사항
- 응답 데이터가 없는 단순 로그아웃 요청에 쿼리 커스텀 훅을 추가하는 것이 좋을지 고민하다가 일단은 쿼리 키까지만 추가하여 사용하고 있습니다. 더 좋은 의견이 있다면 말씀 부탁드립니다.
