### PR TITLE
[Fix] 모각코 페이지 요청 시 기본 page를 '1'로 설정

### DIFF
--- a/app/frontend/src/pages/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/pages/Mogaco/MogacoList.tsx
@@ -6,7 +6,9 @@ import { queryKeys } from '@/queries';
 import * as styles from './MogacoList.css';
 
 export function MogacoList() {
-  const { data: mogacoList, isLoading } = useQuery(queryKeys.mogaco.list());
+  const { data: mogacoList, isLoading } = useQuery(
+    queryKeys.mogaco.list({ page: '1' }),
+  );
 
   if (isLoading) {
     return (

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -3,7 +3,7 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { mogaco } from '@/services';
 
 export const mogacoKeys = createQueryKeys('mogaco', {
-  list: (filters?: { date?: string }) => ({
+  list: (filters?: { date?: string; page?: string }) => ({
     queryKey: [{ filters }],
     queryFn: () => mogaco.list(filters),
   }),

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -11,7 +11,7 @@ export const mogaco = {
     default: '/posts',
   },
 
-  list: async (filters?: { date?: string }) => {
+  list: async (filters?: { date?: string; page?: string }) => {
     const queryString = filters
       ? `?${new URLSearchParams(filters).toString()}`
       : '';


### PR DESCRIPTION
## 설명
- close #345 
- 모각코 페이지 요청 시 page 인자를 '1'로 전달하도록 수정합니다.
- 아직 페이지네이션은 구현되지 않은 상태입니다.

## 완료한 기능 명세
- [x] 모각코 페이지 요청 시 기본 page를 '1'로 설정

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

