### PR TITLE
[Feat] 페이지네이션 미적용 및 오류 예외처리 추가

### DIFF
--- a/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
@@ -27,12 +27,16 @@ export class MogacoController {
   async getMogaco(
     @GetUser() member: Member,
     @Query('date') date?: string,
-    @Query('page') page: number = 1,
+    @Query('page') page?: number,
   ): Promise<MogacoDto[]> {
     if (date) {
       return this.mogacoService.getMogacoByDate(date, member);
     } else {
-      return this.mogacoService.getAllMogaco(member, page);
+      if (page) {
+        return this.mogacoService.getAllMogaco(member, page);
+      } else {
+        return this.mogacoService.getAllMogaco(member);
+      }
     }
   }
 
@@ -58,6 +62,7 @@ export class MogacoController {
   @ApiBody({ type: CreateMogacoDto })
   @ApiResponse({ status: 201, description: 'Successfully created', type: MogacoWithMemberDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Group with id not found' })
   async createMogaco(@Body() createMogacoDto: CreateMogacoDto, @GetUser() member: Member): Promise<Mogaco> {
     return this.mogacoService.createMogaco(createMogacoDto, member);
   }

--- a/app/backend/src/mogaco-boards/mogaco-boards.service.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.service.ts
@@ -9,8 +9,12 @@ import { ParticipantResponseDto } from './dto/response-participants.dto';
 export class MogacoService {
   constructor(private mogacoRepository: MogacoRepository) {}
 
-  async getAllMogaco(member: Member, page: number = 1): Promise<MogacoDto[]> {
-    return this.mogacoRepository.getAllMogaco(member, page);
+  async getAllMogaco(member: Member, page?: number): Promise<MogacoDto[]> {
+    if (page) {
+      return this.mogacoRepository.getAllMogaco(member, page);
+    } else {
+      return this.mogacoRepository.getAllMogaco(member);
+    }
   }
 
   async getMogacoByDate(date: string, member: Member): Promise<MogacoDto[]> {


### PR DESCRIPTION
## 설명
- close #348 

페이지네이션이 미적용된 기본
`http://localhost:8080/posts`의 Get 요청 코드도 추가합니다.
해당 기능은 지도에서 쓰입니다.

이로써 모각코 조회 부분은 
기본 조회
페이지네이션 조회
기간별 조회

세 기능을 가집니다.

게시글을 생성할 때 그룹이 가입되어있지않은 경우에 대해 클라이언트에서 처리를 해주고 있으나 이중으로 추가합니다.

## 완료한 기능 명세
- [x] 페이지네이션 미적용 코드 추가
- [x] 게시글 생성 예외처리 추가

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
@LEEJW1953 @js43o @ttaerrim 

클라이언트분들 확인 부탁드립니다.

페이지네이션 시 기본 페이지를 1로 설정하였으나 제외하였습니다.
클라이언트에서 처리해주시기 바랍니다.

