### PR TITLE
[Refactor] 사이드바 컴포넌트 반응형 UI 개선

### DIFF
--- a/app/frontend/src/components/Input/Textarea.css.ts
+++ b/app/frontend/src/components/Input/Textarea.css.ts
@@ -7,5 +7,6 @@ export const textarea = style([
   input,
   {
     resize: 'none',
+    width: '100%',
   },
 ]);

--- a/app/frontend/src/components/Label/index.tsx
+++ b/app/frontend/src/components/Label/index.tsx
@@ -1,4 +1,4 @@
-import { sansBold12 } from '@/styles/font.css';
+import { sansBold14 } from '@/styles/font.css';
 
 import { container } from './index.css';
 
@@ -16,7 +16,7 @@ export function Label({
   children,
 }: LabelProps) {
   return (
-    <div className={`${container({ theme, shape, disabled })} ${sansBold12}`}>
+    <div className={`${container({ theme, shape, disabled })} ${sansBold14}`}>
       {children}
     </div>
   );

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
@@ -78,6 +78,13 @@ export const title = style([
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
+    fontSize: '1.8rem',
+
+    '@media': {
+      '(min-width: 768px)': {
+        fontSize: '2.4rem',
+      },
+    },
   },
 ]);
 

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
@@ -75,7 +75,6 @@ export const textarea = style([
 export const title = style([
   sansBold24,
   {
-    flexGrow: 0,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/index.css.ts
@@ -88,5 +88,5 @@ export const userList = style({
   gap: '0.8rem',
   maxWidth: '15rem',
   maxHeight: '30rem',
-  overflowY: 'scroll',
+  overflowY: 'auto',
 });

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/GroupWrapper.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/GroupWrapper.tsx
@@ -1,7 +1,6 @@
 import { ResponseMogacoWithMemberDto } from '@morak/apitype';
 
 import { UserChip } from '@/components';
-import { sansBold14 } from '@/styles/font.css';
 
 import * as styles from './index.css';
 
@@ -12,7 +11,7 @@ export function GroupWrapper({
   return (
     <div className={styles.groupWrapper}>
       <UserChip username={member.nickname} profileSrc={member.profilePicture} />
-      <span className={sansBold14}>{groupTitle}</span>
+      <span className={styles.group}>{groupTitle}</span>
     </div>
   );
 }

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/GroupWrapper.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/GroupWrapper.tsx
@@ -1,4 +1,4 @@
-import { ResponseParticipant } from '@morak/apitype';
+import { ResponseMogacoWithMemberDto } from '@morak/apitype';
 
 import { UserChip } from '@/components';
 import { sansBold14 } from '@/styles/font.css';
@@ -6,14 +6,13 @@ import { sansBold14 } from '@/styles/font.css';
 import * as styles from './index.css';
 
 export function GroupWrapper({
-  nickname,
-  profilePicture,
-}: Pick<ResponseParticipant, 'nickname' | 'profilePicture'>) {
+  member,
+  groupTitle,
+}: Pick<ResponseMogacoWithMemberDto, 'member' | 'groupTitle'>) {
   return (
     <div className={styles.groupWrapper}>
-      <UserChip username={nickname} profileSrc={profilePicture} />
-      {/* TODO: group 받아와서 적용 */}
-      <span className={sansBold14}>부스트캠프 웹모바일 8기</span>
+      <UserChip username={member.nickname} profileSrc={member.profilePicture} />
+      <span className={sansBold14}>{groupTitle}</span>
     </div>
   );
 }

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/MogacoInfo.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/MogacoInfo.tsx
@@ -24,17 +24,14 @@ export function MogacoInfo({
     address,
     participants,
     member,
+    groupTitle,
   } = mogaco;
 
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
         <TitleWrapper status={status} title={title} />
-        {/* TODO: group 받아와서 적용 */}
-        <GroupWrapper
-          nickname={member.nickname}
-          profilePicture={member.profilePicture}
-        />
+        <GroupWrapper member={member} groupTitle={groupTitle} />
         <InfoWrapper
           date={date}
           participantCount={participants.length}

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
-import { sansBold24, sansRegular12 } from '@/styles/font.css';
+import { sansBold16, sansBold24, sansRegular14 } from '@/styles/font.css';
 
 export const container = style({
   display: 'flex',
@@ -11,23 +11,36 @@ export const container = style({
   color: vars.color.grayscaleBlack,
   padding: '2rem',
 });
+
+export const group = style([
+  sansBold16,
+  {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+]);
+
 export const groupWrapper = style({
   display: 'flex',
   alignItems: 'center',
   color: vars.color.grayscale200,
   gap: '1.6rem',
 });
+
 export const icon = style({
   fill: vars.color.grayscale200,
 });
+
 export const infoContent = style({
   display: 'flex',
   width: '100%',
   alignItems: 'center',
   gap: '0.4rem',
 });
+
 export const infoText = style([
-  sansRegular12,
+  sansRegular14,
   {
     width: '100%',
     alignItems: 'center',
@@ -37,20 +50,24 @@ export const infoText = style([
     textOverflow: 'ellipsis',
   },
 ]);
+
 export const infoWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '0.4rem',
 });
+
 export const title = style([
   sansBold24,
   { overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' },
 ]);
+
 export const titleWrapper = style({
   display: 'flex',
   gap: '0.4rem',
   alignItems: 'center',
 });
+
 export const wrapper = style({
   display: 'flex',
   flexDirection: 'column',

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
@@ -64,7 +64,7 @@ export const title = style([
 
 export const titleWrapper = style({
   display: 'flex',
-  gap: '0.4rem',
+  gap: '0.8rem',
   alignItems: 'center',
 });
 

--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -24,7 +24,7 @@ export const closeButton = style({
 });
 
 export const closed = style({
-  transform: 'translateX(-40rem)',
+  transform: 'translateX(calc(-100% + 2.4rem))',
 });
 
 export const flip = style({
@@ -46,7 +46,7 @@ export const notParticipated = style([
 
 export const panel = style({
   display: 'flex',
-  width: '40rem',
+  flexGrow: '1',
   height: '100%',
   borderRight: `1px solid ${vars.color.grayscale100}`,
   background: vars.color.grayscaleWhite,
@@ -59,6 +59,8 @@ export const wrapper = style({
   top: '8.5rem',
   left: 0,
   zIndex: 10,
+  width: '100%',
+  maxWidth: '40rem',
   height: 'calc(100% - 8.6rem)',
   transition: 'transform 0.5s',
 });

--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -7,7 +7,7 @@ export const closeButton = style({
   display: 'flex',
   alignItems: 'center',
   width: '2.4rem',
-  height: '4.8rem',
+  height: '6.4rem',
   padding: 0,
   border: `1px solid ${vars.color.grayscale200}`,
   borderRadius: '0 0.8rem 0.8rem 0',

--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -47,6 +47,7 @@ export const notParticipated = style([
 export const panel = style({
   display: 'flex',
   flexGrow: '1',
+  maxWidth: 'calc(100% - 2.4rem)',
   height: '100%',
   borderRight: `1px solid ${vars.color.grayscale100}`,
   background: vars.color.grayscaleWhite,


### PR DESCRIPTION
## 설명
 close #330
- 사이드바 컴포넌트의 반응형 UI를 개선합니다.
- **Textarea, Label 컴포넌트에 약간의 변경사항이 추가되었습니다.** (자세한 것은 파일 변경사항을 확인해 주세요)
- 모각코 정보 사이드바에서 실제 모각코 그룹명을 사용하도록 변경했습니다. (반응형 작업은 아니어서 말씀드립니다)

## 완료한 기능 명세
- [x] 사이드바 크기가 유동적으로 줄어듦
- [x] 텍스트 ellipsis 처리
- [x] **사이드바 모각코 정보에서 실제 그룹명을 표시하도록 변경**
- [x] **사이드바 열기/닫기 버튼 height 늘림**
- [x] 기타 폰트 크기, 간격 조정

### 동작 화면

- 채팅 UI

https://github.com/boostcampwm2023/web17_morak/assets/50646827/a0c57ccc-5d04-4403-8897-e0ce305313b7

- 모각코 정보

https://github.com/boostcampwm2023/web17_morak/assets/50646827/f660a91c-a9af-4752-9e47-e4b6ae152069

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

