### PR TITLE
[Refactor] 그룹 아이템 컴포넌트 반응형 UI 개선

### DIFF
--- a/app/frontend/src/components/Group/GroupButton.tsx
+++ b/app/frontend/src/components/Group/GroupButton.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components/Button';
+
+import { useGroupJoinAndLeave } from './hooks/useGroupJoinLeave';
+import { useGroupModal } from './hooks/useGroupModal';
+
+type GroupButtonProps = {
+  id: string;
+  owned: boolean;
+  joined: boolean;
+};
+
+export function GroupButton({ id, owned, joined }: GroupButtonProps) {
+  const { handleLeave, handleJoin } = useGroupJoinAndLeave();
+  const { openLeaveModal, openJoinModal } = useGroupModal();
+
+  const onClickLeave = () =>
+    openLeaveModal({ onClickConfirm: () => handleLeave(id) });
+  const onClickJoin = () =>
+    openJoinModal({ onClickConfirm: () => handleJoin(id) });
+
+  return (
+    <>
+      {owned && (
+        <Button type="button" theme="danger" shape="fill" size="medium">
+          그룹 삭제
+        </Button>
+      )}
+      {!owned &&
+        (joined ? (
+          <Button
+            type="button"
+            theme="danger"
+            shape="fill"
+            size="medium"
+            onClick={onClickLeave}
+          >
+            나가기
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            theme="primary"
+            shape="fill"
+            size="medium"
+            onClick={onClickJoin}
+          >
+            참여하기
+          </Button>
+        ))}
+    </>
+  );
+}

--- a/app/frontend/src/components/Group/index.css.ts
+++ b/app/frontend/src/components/Group/index.css.ts
@@ -5,6 +5,7 @@ import { sansBold16, sansBold20, sansRegular16 } from '@/styles/font.css';
 
 const {
   grayscale50,
+  grayscale100,
   grayscale200,
   grayscale400,
   grayscaleWhite,
@@ -38,6 +39,16 @@ export const container = style({
   },
 });
 
+export const copyButton = style({
+  display: 'flex',
+  padding: '0.4rem',
+  borderRadius: '50%',
+
+  ':hover': {
+    background: grayscale100,
+  },
+});
+
 export const count = style([
   sansRegular16,
   {
@@ -51,7 +62,7 @@ export const count = style([
 export const detail = style({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.8rem',
+  gap: '0.4rem',
 });
 
 export const groupCode = style({

--- a/app/frontend/src/components/Group/index.css.ts
+++ b/app/frontend/src/components/Group/index.css.ts
@@ -65,7 +65,7 @@ export const desktop = style({
   display: 'flex',
 
   '@media': {
-    'screen and (max-width:425px)': {
+    'screen and (max-width:768px)': {
       display: 'none',
     },
   },
@@ -73,6 +73,7 @@ export const desktop = style({
 
 export const detail = style({
   display: 'flex',
+  justifyContent: 'space-between',
   alignItems: 'center',
   gap: '0.4rem',
 });
@@ -85,7 +86,7 @@ export const mobile = style({
   display: 'none',
 
   '@media': {
-    'screen and (max-width:425px)': {
+    'screen and (max-width:768px)': {
       display: 'flex',
     },
   },

--- a/app/frontend/src/components/Group/index.css.ts
+++ b/app/frontend/src/components/Group/index.css.ts
@@ -16,6 +16,7 @@ export const code = style([
   sansBold16,
   {
     display: 'flex',
+    flexGrow: 1,
     alignItems: 'center',
     gap: '0.4rem',
     color: grayscale200,
@@ -29,6 +30,7 @@ export const container = style({
   border: `1px solid ${grayscale200}`,
   backgroundColor: grayscaleWhite,
   padding: '2rem',
+  paddingBottom: '1.6rem',
   gap: '0.8rem',
   cursor: 'pointer',
 
@@ -59,6 +61,16 @@ export const count = style([
   },
 ]);
 
+export const desktop = style({
+  display: 'flex',
+
+  '@media': {
+    'screen and (max-width:425px)': {
+      display: 'none',
+    },
+  },
+});
+
 export const detail = style({
   display: 'flex',
   alignItems: 'center',
@@ -69,25 +81,26 @@ export const groupCode = style({
   marginLeft: '0.4rem',
 });
 
-export const info = style({
-  display: 'flex',
-  gap: '0.8rem',
-  minWidth: 0,
+export const mobile = style({
+  display: 'none',
+
+  '@media': {
+    'screen and (max-width:425px)': {
+      display: 'flex',
+    },
+  },
 });
 
 export const title = style([
   sansBold20,
   {
     color: grayscaleBlack,
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
   },
 ]);
 
 export const titleWrapper = style({
   display: 'flex',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'start',
   gap: '0.8rem',
 });

--- a/app/frontend/src/components/Group/index.css.ts
+++ b/app/frontend/src/components/Group/index.css.ts
@@ -72,12 +72,16 @@ export const groupCode = style({
 export const info = style({
   display: 'flex',
   gap: '0.8rem',
+  minWidth: 0,
 });
 
 export const title = style([
   sansBold20,
   {
     color: grayscaleBlack,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
   },
 ]);
 
@@ -85,4 +89,5 @@ export const titleWrapper = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  gap: '0.8rem',
 });

--- a/app/frontend/src/components/Group/index.css.ts
+++ b/app/frontend/src/components/Group/index.css.ts
@@ -1,22 +1,26 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
-import { sansBold16, sansBold24, sansRegular16 } from '@/styles/font.css';
+import { sansBold16, sansBold20, sansRegular16 } from '@/styles/font.css';
 
 const {
-  grayscale200,
-  grayscaleWhite,
-  grayscale500,
-  grayscaleBlack,
   grayscale50,
+  grayscale200,
+  grayscale400,
+  grayscaleWhite,
+  grayscaleBlack,
 } = vars.color;
+
 export const code = style([
   sansBold16,
   {
-    color: grayscale200,
     display: 'flex',
+    alignItems: 'center',
+    gap: '0.4rem',
+    color: grayscale200,
   },
 ]);
+
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -25,43 +29,49 @@ export const container = style({
   backgroundColor: grayscaleWhite,
   padding: '2rem',
   gap: '0.8rem',
+  cursor: 'pointer',
 
   selectors: {
     [`&:hover`]: {
       backgroundColor: grayscale50,
-      cursor: 'pointer',
     },
   },
 });
+
 export const count = style([
   sansRegular16,
   {
     display: 'flex',
     alignItems: 'center',
     gap: '0.4rem',
-    color: grayscale500,
+    color: grayscale400,
   },
 ]);
+
 export const detail = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.8rem',
 });
+
 export const groupCode = style({
   marginLeft: '0.4rem',
 });
+
 export const info = style({
   display: 'flex',
   gap: '0.8rem',
 });
+
 export const title = style([
-  sansBold24,
+  sansBold20,
   {
     color: grayscaleBlack,
   },
 ]);
+
 export const titleWrapper = style({
   display: 'flex',
-  alignContent: 'center',
   justifyContent: 'space-between',
+  alignItems: 'center',
 });

--- a/app/frontend/src/components/Group/index.tsx
+++ b/app/frontend/src/components/Group/index.tsx
@@ -3,10 +3,8 @@ import { ReactComponent as Crown } from '@/assets/icons/crown.svg';
 import { ReactComponent as Count } from '@/assets/icons/people.svg';
 import { vars } from '@/styles';
 
-import { useGroupJoinAndLeave } from './hooks/useGroupJoinLeave';
-import { useGroupModal } from './hooks/useGroupModal';
+import { GroupButton } from './GroupButton';
 import * as styles from './index.css';
-import { Button } from '../Button';
 
 const { grayscale200 } = vars.color;
 
@@ -17,14 +15,6 @@ type GroupProps = {
   name: string;
 };
 export function Group({ id, owned = false, name, joined = false }: GroupProps) {
-  const { handleLeave, handleJoin } = useGroupJoinAndLeave();
-  const { openLeaveModal, openJoinModal } = useGroupModal();
-
-  const onClickLeave = () =>
-    openLeaveModal({ onClickConfirm: () => handleLeave(id) });
-  const onClickJoin = () =>
-    openJoinModal({ onClickConfirm: () => handleJoin(id) });
-
   return (
     <div className={styles.container}>
       <div className={styles.titleWrapper}>
@@ -36,33 +26,7 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
             <span>200</span>
           </div>
         </div>
-        {owned && (
-          <Button type="button" theme="danger" shape="fill" size="medium">
-            그룹 삭제
-          </Button>
-        )}
-        {!owned &&
-          (joined ? (
-            <Button
-              type="button"
-              theme="danger"
-              shape="fill"
-              size="medium"
-              onClick={onClickLeave}
-            >
-              나가기
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              theme="primary"
-              shape="fill"
-              size="medium"
-              onClick={onClickJoin}
-            >
-              참여하기
-            </Button>
-          ))}
+        <GroupButton id={id} owned={owned} joined={joined} />
       </div>
       {!owned && (
         <div className={styles.detail}>

--- a/app/frontend/src/components/Group/index.tsx
+++ b/app/frontend/src/components/Group/index.tsx
@@ -67,8 +67,9 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
       {owned && (
         <div className={styles.detail}>
           <div className={styles.code}>
-            <span>그룹 코드 | </span>
-            <span className={styles.groupCode}>FDGSIUH4RUR89U324R98</span>
+            <span>그룹 코드</span>
+            <span>|</span>
+            <span>FDGSIUH4RUR89U324R98</span>
           </div>
           <button type="button">
             <Copy width={24} height={24} fill={grayscale200} />

--- a/app/frontend/src/components/Group/index.tsx
+++ b/app/frontend/src/components/Group/index.tsx
@@ -1,8 +1,6 @@
-import { ReactComponent as Copy } from '@/assets/icons/copy.svg';
 import { ReactComponent as Crown } from '@/assets/icons/crown.svg';
 import { ReactComponent as Count } from '@/assets/icons/people.svg';
 import { vars } from '@/styles';
-import { sansRegular16 } from '@/styles/font.css';
 
 import { GroupButton } from './GroupButton';
 import * as styles from './index.css';
@@ -32,6 +30,7 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
       {!owned && (
         <div className={styles.detail}>
           <div className={styles.code}>
+            {/* 
             <span>그룹 코드</span>
             <span className={styles.desktop}>
               <span className={sansRegular16}>FDGSIUH4RUR89U324R98</span>
@@ -39,6 +38,7 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
             <button type="button" className={styles.copyButton}>
               <Copy width={24} height={24} fill={grayscale200} />
             </button>
+            */}
           </div>
           <div className={styles.mobile}>
             <GroupButton id={id} owned={owned} joined={joined} />

--- a/app/frontend/src/components/Group/index.tsx
+++ b/app/frontend/src/components/Group/index.tsx
@@ -64,14 +64,14 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
             </Button>
           ))}
       </div>
-      {owned && (
+      {!owned && (
         <div className={styles.detail}>
           <div className={styles.code}>
             <span>그룹 코드</span>
             <span>|</span>
             <span>FDGSIUH4RUR89U324R98</span>
           </div>
-          <button type="button">
+          <button type="button" className={styles.copyButton}>
             <Copy width={24} height={24} fill={grayscale200} />
           </button>
         </div>

--- a/app/frontend/src/components/Group/index.tsx
+++ b/app/frontend/src/components/Group/index.tsx
@@ -2,6 +2,7 @@ import { ReactComponent as Copy } from '@/assets/icons/copy.svg';
 import { ReactComponent as Crown } from '@/assets/icons/crown.svg';
 import { ReactComponent as Count } from '@/assets/icons/people.svg';
 import { vars } from '@/styles';
+import { sansRegular16 } from '@/styles/font.css';
 
 import { GroupButton } from './GroupButton';
 import * as styles from './index.css';
@@ -18,26 +19,30 @@ export function Group({ id, owned = false, name, joined = false }: GroupProps) {
   return (
     <div className={styles.container}>
       <div className={styles.titleWrapper}>
-        <div className={styles.info}>
-          {owned && <Crown />}
-          <div className={styles.title}>{name}</div>
-          <div className={styles.count}>
-            <Count width={16} height={16} fill={grayscale200} />
-            <span>200</span>
-          </div>
+        {owned && <Crown />}
+        <div className={styles.title}>{name}</div>
+        <div className={styles.desktop}>
+          <GroupButton id={id} owned={owned} joined={joined} />
         </div>
-        <GroupButton id={id} owned={owned} joined={joined} />
+      </div>
+      <div className={styles.count}>
+        <Count width={16} height={16} fill={grayscale200} />
+        <span>200</span>
       </div>
       {!owned && (
         <div className={styles.detail}>
           <div className={styles.code}>
             <span>그룹 코드</span>
-            <span>|</span>
-            <span>FDGSIUH4RUR89U324R98</span>
+            <span className={styles.desktop}>
+              <span className={sansRegular16}>FDGSIUH4RUR89U324R98</span>
+            </span>
+            <button type="button" className={styles.copyButton}>
+              <Copy width={24} height={24} fill={grayscale200} />
+            </button>
           </div>
-          <button type="button" className={styles.copyButton}>
-            <Copy width={24} height={24} fill={grayscale200} />
-          </button>
+          <div className={styles.mobile}>
+            <GroupButton id={id} owned={owned} joined={joined} />
+          </div>
         </div>
       )}
     </div>

--- a/app/frontend/src/styles/font.css.ts
+++ b/app/frontend/src/styles/font.css.ts
@@ -59,6 +59,13 @@ export const sansBold18 = style([
   },
 ]);
 
+export const sansBold20 = style([
+  sansBold,
+  {
+    fontSize: '2.0rem',
+  },
+]);
+
 export const sansBold24 = style([
   sansBold,
   {


### PR DESCRIPTION
## 설명
- close #331 
- 그룹 아이템 컴포넌트의 반응형 UI를 개선합니다.
- 현재 뷰포트 너비에 따라 그룹 버튼의 위치가 위/아래로 달라지게 했습니다. (`desktop`, `mobile` 스타일 객체 선언)
- **참여한 그룹의 이름은 중요한 정보라고 생각해서 줄임 효과(ellipsis)를 넣지 않고 모두 표시되도록 하였습니다.** 처음 그룹을 생성할 때 적절히 글자 수 제한을 두는 쪽으로 가는 것이 좋을 것 같습니다.
  - 줄임표를 넣어서 한 줄만 표시한다면? => `부스트캠프 웹·모바일 8기`와 `부스트캠프 웹·모바일 9기`가 모두 `부스트캠프 웹...`과 같이 표시되어 구분할 수 없는 경우가 생길 수 있음
- 인원 수 표시를 제목과 같은 줄에서 제목 밑 2번째 줄로 내렸습니다.
- 정확한 그룹 코드는 복사 버튼이 있으므로 생략해도 괜찮다고 판단하여 모바일에서 표시를 생략했습니다.

## 완료한 기능 명세
- [x] 그룹 아이템 컴포넌트 반응형 UI 개선
- [x] 그룹 버튼 컴포넌트 분리

### 동작 화면
https://github.com/boostcampwm2023/web17_morak/assets/50646827/777811e5-3398-49be-8474-6917fecfa818

## 리뷰 요청 사항
- 디자인에 관해 다른 의견 있으시다면 말씀 부탁드립니다!
