### PR TITLE
[Refactor] 모각코 게시글 데이터 페칭 에러 및 등록된 게시글이 0개일 때 UI 표시

### DIFF
--- a/app/frontend/src/pages/Mogaco/ErrorPage.css.ts
+++ b/app/frontend/src/pages/Mogaco/ErrorPage.css.ts
@@ -1,0 +1,18 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles';
+import { sansRegular16 } from '@/styles/font.css';
+
+const { morakRed } = vars.color;
+
+export const text = style([
+  sansRegular16,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '0.8rem',
+    textAlign: 'center',
+    color: morakRed,
+  },
+]);

--- a/app/frontend/src/pages/Mogaco/ErrorPage.tsx
+++ b/app/frontend/src/pages/Mogaco/ErrorPage.tsx
@@ -1,0 +1,25 @@
+import { Button, MessageWrapper } from '@/components';
+
+import * as styles from './ErrorPage.css';
+
+export function ErrorPage() {
+  const onClickRefresh = () => {
+    window.location.href = '/mogaco';
+  };
+
+  return (
+    <MessageWrapper>
+      <p className={styles.text}>
+        정보를 불러오는 데에 실패했습니다.
+        <Button
+          theme="primary"
+          shape="line"
+          size="large"
+          onClick={onClickRefresh}
+        >
+          새로고침
+        </Button>
+      </p>
+    </MessageWrapper>
+  );
+}

--- a/app/frontend/src/pages/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/pages/Mogaco/MogacoList.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { Loading, MogacoItem } from '@/components';
+import { Error, Loading, MogacoItem } from '@/components';
 import { queryKeys } from '@/queries';
 
 import { EmptyPage } from './EmptyPage';
@@ -21,6 +21,10 @@ export function MogacoList({ currentPage }: MogacoListProp) {
         <Loading />
       </div>
     );
+  }
+
+  if (!mogacoList) {
+    return <Error message="모각코 정보를 불러오는 데에 실패했습니다." />;
   }
 
   return (

--- a/app/frontend/src/pages/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/pages/Mogaco/MogacoList.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { Error, Loading, MogacoItem } from '@/components';
+import { Loading, MogacoItem } from '@/components';
 import { queryKeys } from '@/queries';
 
 import { EmptyPage } from './EmptyPage';
+import { ErrorPage } from './ErrorPage';
 import * as styles from './MogacoList.css';
 
 type MogacoListProp = {
@@ -24,7 +25,11 @@ export function MogacoList({ currentPage }: MogacoListProp) {
   }
 
   if (!mogacoList) {
-    return <Error message="모각코 정보를 불러오는 데에 실패했습니다." />;
+    return (
+      <div className={styles.container}>
+        <ErrorPage />
+      </div>
+    );
   }
 
   return (

--- a/app/frontend/src/pages/Mogaco/NoContents.css.ts
+++ b/app/frontend/src/pages/Mogaco/NoContents.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/styles';
+import { sansRegular18 } from '@/styles/font.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '0.4rem',
+  height: '32rem',
+  filter: 'grayscale(80%)',
+});
+
+export const text = style([
+  sansRegular18,
+  {
+    textAlign: 'center',
+    lineHeight: 1.4,
+    color: vars.color.grayscale400,
+  },
+]);

--- a/app/frontend/src/pages/Mogaco/NoContents.tsx
+++ b/app/frontend/src/pages/Mogaco/NoContents.tsx
@@ -1,0 +1,15 @@
+import { ReactComponent as Morak } from '@/assets/icons/morak.svg';
+
+import * as styles from './NoContents.css';
+
+export function NoContents() {
+  return (
+    <div className={styles.container}>
+      <Morak width={128} height={128} />
+      <p className={styles.text}>
+        아직 속한 그룹에 등록된 모각코가 없습니다.
+        <br />첫 모각코를 열어보세요.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 설명
- close #332 
- 모각코 데이터를 불러오는 데 실패하거나 현재 속한 그룹에 등록된 모각코 게시글이 0개인 경우 적절한 UI를 표시합니다.

## 완료한 기능 명세
- [x] 데이터 페칭 실패 시 `Error` 컴포넌트 반환
- [x] 데이터가 0개일 때 `NoContents` 컴포넌트 반환

### 스크린샷
- 페칭 실패
![화면 캡처 2023-12-07 142750](https://github.com/boostcampwm2023/web17_morak/assets/50646827/d4f0ca1e-5d16-4e58-9b11-b893d0a440f7)
- 게시글 0개
![화면 캡처 2023-12-07 142057](https://github.com/boostcampwm2023/web17_morak/assets/50646827/c08809c0-85bc-43ea-a882-79f5166d9069)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

