### PR TITLE
[Feat] 모각코 모집 중/모집 마감/종료 필터링 구현 및 최대 인원 수 초과 시 오류 처리

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -93,7 +93,6 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node",
-    "workerThreads": true
+    "testEnvironment": "node"
   }
 }

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.spec.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.spec.ts
@@ -20,6 +20,7 @@ describe('MogacoRepository', () => {
               findUnique: jest.fn(),
               create: jest.fn(),
               update: jest.fn(),
+              updateMany: jest.fn(),
             },
             groupToUser: {
               findMany: jest.fn().mockResolvedValueOnce([{ groupId: BigInt(1), userId: mockMember.id }]),
@@ -29,6 +30,7 @@ describe('MogacoRepository', () => {
               findUnique: jest.fn(),
               create: jest.fn(),
               delete: jest.fn(),
+              count: jest.fn(),
             },
           },
         },

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -326,7 +326,7 @@ export class MogacoRepository {
       },
     });
 
-    if (participantsCount >= mogaco.maxHumanCount) {
+    if (participantsCount + 1 >= mogaco.maxHumanCount) {
       await this.prisma.mogaco.update({
         where: { id: mogaco.id },
         data: {

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -29,6 +29,16 @@ export class MogacoRepository {
     }
   }
 
+  private async getParticipantsCount(id: number): Promise<number> {
+    const participantsCount = await this.prisma.participant.count({
+      where: {
+        postId: id,
+      },
+    });
+
+    return participantsCount;
+  }
+
   async getAllMogaco(member: Member, page?: number): Promise<MogacoDto[]> {
     const userGroups = await this.prisma.groupToUser.findMany({
       where: { userId: member.id },
@@ -427,15 +437,5 @@ export class MogacoRepository {
         },
       },
     });
-  }
-
-  async getParticipantsCount(id: number): Promise<number> {
-    const participantsCount = await this.prisma.participant.count({
-      where: {
-        postId: id,
-      },
-    });
-
-    return participantsCount;
   }
 }


### PR DESCRIPTION
## 설명
- close #393 
- close #395 

현재 모각코 상태 코드의 경우 전부 모집 중으로만 처리가 되고 있습니다.
최대 인원수에 맞아지면 모집 중 -> 모집 마감
최대 인원수에서 누군가 취소를 할 경우 모집 마감 -> 모집 중으로 변경되어야합니다.

또한 모각코 시행일자 Date가 지난 경우 상태코드를 종료로 변경해야합니다.

그리고 현재 모각코 참가를 최대 인원수를 넘겨도 계속 참여할 수 있기 때문에 그에 해당하는 오류처리도 진행하였습니다.

## 완료한 기능 명세
- [x] 모각코 모집 중/모집 마감/종료 필터링 구현
- [x] 최대 인원 수 초과 시 오류 처리
- [x] 테스트코드 mock 메서드 추가

### 스크린샷
[개발 일지 기록](https://ttaerrim.notion.site/4a5b762b87f345d598bf87115b894ce9?pvs=4)


## 리뷰 요청 사항
@ttaerrim @LEEJW1953 @js43o 

