### PR TITLE
[Feat] 그룹 조회 시 해당 그룹 인원 추가 반환

### DIFF
--- a/app/backend/src/groups/dto/groups.dto.ts
+++ b/app/backend/src/groups/dto/groups.dto.ts
@@ -1,4 +1,4 @@
-import { ResponseGroupsDto } from '@morak/apitype/dto/response/groups';
+import { ResponseGroupsDto, ResponseGroupsWithMemberCountDto } from '@morak/apitype/dto/response/groups';
 import { ApiProperty } from '@nestjs/swagger';
 import { Bigint } from '@morak/apitype/dto/type';
 
@@ -8,4 +8,15 @@ export class GroupsDto implements ResponseGroupsDto {
 
   @ApiProperty({ description: 'title of the Group', example: '부스트캠프 웹・모바일 8기' })
   title: string;
+}
+
+export class GroupsWithMemberCountDto implements ResponseGroupsWithMemberCountDto {
+  @ApiProperty({ description: 'ID of the Group', example: '1' })
+  id: Bigint;
+
+  @ApiProperty({ description: 'title of the Group', example: '부스트캠프 웹・모바일 8기' })
+  title: string;
+
+  @ApiProperty({ description: 'member count of the Group', example: '200' })
+  memberCount: number;
 }

--- a/app/backend/src/groups/groups.controller.spec.ts
+++ b/app/backend/src/groups/groups.controller.spec.ts
@@ -34,8 +34,8 @@ describe('GroupsController', () => {
   describe('getAllGroups', () => {
     it('모든 그룹을 반환해야 함', async () => {
       const expectedGroups = [
-        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기' },
-        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기' },
+        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기', membersCount: 212 },
+        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기', membersCount: 187 },
       ];
       jest.spyOn(service, 'getAllGroups').mockResolvedValue(expectedGroups);
 

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -4,7 +4,7 @@ import { GroupsService } from './groups.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
 import { Group, Member } from '@prisma/client';
-import { GroupsDto } from './dto/groups.dto';
+import { GroupsDto, GroupsWithMemberCountDto } from './dto/groups.dto';
 import { MemberInformationDto } from 'src/member/dto/member.dto';
 import { ParticipantResponseDto } from 'src/mogaco-boards/dto/response-participants.dto';
 import { CreateGroupsDto } from './dto/create-groups.dto';
@@ -21,9 +21,9 @@ export class GroupsController {
     summary: '모든 그룹 조회',
     description: '존재하는 모든 그룹을 조회합니다.',
   })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [GroupsDto] })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [GroupsWithMemberCountDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getAllGroups(): Promise<Group[]> {
+  async getAllGroups(): Promise<(Group & { membersCount: number })[]> {
     return this.groupsService.getAllGroups();
   }
 

--- a/app/backend/src/groups/groups.repository.spec.ts
+++ b/app/backend/src/groups/groups.repository.spec.ts
@@ -38,8 +38,8 @@ describe('GroupsRepository', () => {
   describe('getAllGroups', () => {
     it('모든 그룹을 반환해야 함', async () => {
       const expectedGroups = [
-        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기' },
-        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기' },
+        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기', membersCount: 212 },
+        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기', membersCount: 187 },
       ];
       jest.spyOn(prismaService.group, 'findMany').mockResolvedValue(expectedGroups);
 

--- a/app/backend/src/groups/groups.service.spec.ts
+++ b/app/backend/src/groups/groups.service.spec.ts
@@ -33,8 +33,8 @@ describe('GroupsService', () => {
   describe('getAllGroups', () => {
     it('모든 그룹을 반환해야 함', async () => {
       const expectedGroups = [
-        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기' },
-        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기' },
+        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기', membersCount: 212 },
+        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기', membersCount: 187 },
       ];
       jest.spyOn(repository, 'getAllGroups').mockResolvedValue(expectedGroups);
 

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -8,7 +8,7 @@ import { CreateGroupsDto } from './dto/create-groups.dto';
 export class GroupsService {
   constructor(private groupsRepository: GroupsRepository) {}
 
-  async getAllGroups(): Promise<Group[]> {
+  async getAllGroups(): Promise<(Group & { membersCount: number })[]> {
     return this.groupsRepository.getAllGroups();
   }
 

--- a/packages/apitype/dto/response/groups.ts
+++ b/packages/apitype/dto/response/groups.ts
@@ -4,3 +4,9 @@ export interface ResponseGroupsDto {
   id: Bigint;
   title: string;
 }
+
+export interface ResponseGroupsWithMemberCountDto {
+  id: Bigint;
+  title: string;
+  memberCount: number;
+}


### PR DESCRIPTION
## 설명
- close #394 

전체 그룹 조회 시 그룹 인원이 몇 명인지도 조회합니다.

## 완료한 기능 명세
- [x] 그룹 조회 시 해당 그룹 인원 추가 반환
- [x] Swagger
- [x] TestCode

### 스크린샷
<img width="774" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/494a31ab-8093-4305-9723-449e30005533">


## 리뷰 요청 사항
@ttaerrim @LEEJW1953 @js43o 

