### PR TITLE
[Feat] 사용자가 참여한 모각코 조회 API 구현

### DIFF
--- a/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
@@ -42,8 +42,8 @@ export class MogacoController {
 
   @Get('/my-mogacos')
   @ApiOperation({
-    summary: '가입 그룹 확인',
-    description: '해당 사용자가 가입한 그룹을 확인합니다.',
+    summary: '가입한 모각코 확인',
+    description: '해당 사용자가 가입한 모각코를 확인합니다.',
   })
   @ApiResponse({ status: 200, description: 'Successfully Check', type: [MogacoDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })

--- a/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
@@ -40,6 +40,17 @@ export class MogacoController {
     }
   }
 
+  @Get('/my-mogacos')
+  @ApiOperation({
+    summary: '가입 그룹 확인',
+    description: '해당 사용자가 가입한 그룹을 확인합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully Check', type: [MogacoDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyMogacos(@GetUser() member: Member): Promise<MogacoDto[]> {
+    return this.mogacoService.getMyMogacos(member);
+  }
+
   @Get('/:id')
   @ApiOperation({
     summary: '특정 모각코 조회',

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -170,6 +170,49 @@ export class MogacoRepository {
     }));
   }
 
+  async getMyMogacos(member: Member): Promise<MogacoDto[]> {
+    const userGroups = await this.prisma.groupToUser.findMany({
+      where: { userId: member.id },
+      select: { groupId: true },
+    });
+
+    const userGroupIds = userGroups.map((group) => group.groupId);
+
+    const mogacos = await this.prisma.mogaco.findMany({
+      where: {
+        deletedAt: null,
+        groupId: {
+          in: userGroupIds,
+        },
+      },
+      include: {
+        group: true,
+      },
+    });
+
+    const mappedMogacos = mogacos.map((mogaco) => ({
+      id: mogaco.id.toString(),
+      groupId: mogaco.group.id.toString(),
+      title: mogaco.title,
+      contents: mogaco.contents,
+      date: mogaco.date,
+      maxHumanCount: mogaco.maxHumanCount,
+      address: mogaco.address,
+      latitude: Number(mogaco.latitude),
+      longitude: Number(mogaco.longitude),
+      status: mogaco.status,
+      createdAt: mogaco.createdAt,
+      updatedAt: mogaco.updatedAt,
+      deletedAt: mogaco.deletedAt,
+      group: {
+        id: mogaco.group.id.toString(),
+        title: mogaco.group.title,
+      },
+    }));
+
+    return mappedMogacos;
+  }
+
   async getMogacoById(id: number, member: Member): Promise<MogacoWithMemberDto> {
     const mogaco = await this.prisma.mogaco.findUnique({
       where: { id, deletedAt: null },

--- a/app/backend/src/mogaco-boards/mogaco-boards.service.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.service.ts
@@ -21,6 +21,10 @@ export class MogacoService {
     return this.mogacoRepository.getMogacoByDate(date, member);
   }
 
+  async getMyMogacos(member: Member): Promise<MogacoDto[]> {
+    return this.mogacoRepository.getMyMogacos(member);
+  }
+
   async getMogacoById(id: number, member: Member): Promise<MogacoWithMemberDto> {
     return this.mogacoRepository.getMogacoById(id, member);
   }


### PR DESCRIPTION
## 설명
- close #396 

프로필 페이지에서 사용자가 현재 속한 모각코를 조회하기 위한 API를 구현합니다.

## 완료한 기능 명세
- [x] 참여 모각코 조회 API 구현

### 스크린샷
<img width="700" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/33d9ff88-06e5-4ac3-bce5-98878910a5ec">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

