### PR TITLE
[Feat] 로그인 인가 처리 방식 변경 (bearer token 사용 x)

### DIFF
--- a/app/backend/libs/utils/swagger.ts
+++ b/app/backend/libs/utils/swagger.ts
@@ -8,15 +8,6 @@ export function setupSwagger(app: INestApplication): void {
     .setVersion('1.0.0')
     .addTag('moraks')
     .addCookieAuth('token')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        name: 'JWT',
-        in: 'header',
-      },
-      'access_token',
-    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -81,7 +81,7 @@ export class AuthController {
 
       res.setHeader('Authorization', 'Bearer ' + [tokens.access_token, tokens.refresh_token]);
 
-      res.cookie('access_token', tokens.access_token, { httpOnly: false, maxAge: getSecret('MAX_AGE_ACCESS_TOKEN') });
+      res.cookie('access_token', tokens.access_token, { httpOnly: true, maxAge: getSecret('MAX_AGE_ACCESS_TOKEN') });
       res.cookie('refresh_token', tokens.refresh_token, {
         httpOnly: true,
         maxAge: getSecret('MAX_AGE_REFRESH_TOKEN'),
@@ -119,14 +119,14 @@ export class AuthController {
 
       res.setHeader('Authorization', 'Bearer ' + newAccessToken);
       res.cookie('access_token', newAccessToken, {
-        httpOnly: false,
+        httpOnly: true,
         maxAge: getSecret('MAX_AGE_ACCESS_TOKEN'),
       });
 
       res.json({ newAccessToken });
     } catch (err) {
-      res.clearCookie('access_token', { httpOnly: false });
-      res.clearCookie('refresh_token', { httpOnly: false });
+      res.clearCookie('access_token', { httpOnly: true });
+      res.clearCookie('refresh_token', { httpOnly: true });
       throw new UnauthorizedException('Failed to refresh token');
     }
   }
@@ -149,8 +149,8 @@ export class AuthController {
       const { providerId } = body;
       await this.authService.logout(providerId);
 
-      res.clearCookie('access_token', { httpOnly: false });
-      res.clearCookie('refresh_token', { httpOnly: false });
+      res.clearCookie('access_token', { httpOnly: true });
+      res.clearCookie('refresh_token', { httpOnly: true });
     } catch (error) {
       console.error('Logout error:', error);
       throw new UnauthorizedException('Failed to logout');

--- a/app/backend/src/auth/auth.module.ts
+++ b/app/backend/src/auth/auth.module.ts
@@ -5,11 +5,12 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { AuthRepository } from './auth.repository';
 import { AtStrategy, GoogleStrategy, RtStrategy } from './strategies';
+import { AtGuard } from './guards/at.guard';
 
 @Module({
   imports: [JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService, AuthRepository, GoogleStrategy, AtStrategy, RtStrategy],
-  exports: [AuthService, AtStrategy],
+  providers: [AuthService, AuthRepository, GoogleStrategy, AtStrategy, RtStrategy, AtGuard],
+  exports: [AuthService, JwtModule, AtStrategy, AtGuard],
 })
 export class AuthModule {}

--- a/app/backend/src/auth/auth.repository.ts
+++ b/app/backend/src/auth/auth.repository.ts
@@ -13,6 +13,18 @@ export class AuthRepository {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
+  async getUserIdFromToken(providerId: string): Promise<bigint> {
+    const user = await this.prisma.member.findUnique({
+      where: {
+        providerId,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return user.id;
+  }
   async saveUser(userDto: CreateUserDto): Promise<Member> {
     const { providerId, socialType, email, nickname, profilePicture } = userDto;
 

--- a/app/backend/src/auth/guards/at.guard.ts
+++ b/app/backend/src/auth/guards/at.guard.ts
@@ -1,5 +1,39 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
+import { getSecret } from '@morak/vault';
 
 @Injectable()
-export class AtGuard extends AuthGuard('jwt') {}
+export class AtGuard extends AuthGuard('jwt') {
+  constructor(private jwtService: JwtService) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+
+    if (!request.cookies) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const accessToken = request.cookies.access_token;
+
+    try {
+      const decodedToken = this.jwtService.verify(accessToken, {
+        secret: getSecret('JWT_ACCESS_SECRET'),
+      });
+
+      const { userId, providerId, socialType, email, profilePicture, nickname } = decodedToken;
+
+      const userIdBigInt = BigInt(userId);
+
+      request.user = { id: userIdBigInt, providerId, socialType, email, profilePicture, nickname };
+
+      console.log(request.user);
+
+      return true;
+    } catch (error) {
+      throw new UnauthorizedException('Invalid access token');
+    }
+  }
+}

--- a/app/backend/src/auth/guards/at.guard.ts
+++ b/app/backend/src/auth/guards/at.guard.ts
@@ -24,12 +24,9 @@ export class AtGuard extends AuthGuard('jwt') {
       });
 
       const { userId, providerId, socialType, email, profilePicture, nickname } = decodedToken;
-
       const userIdBigInt = BigInt(userId);
 
       request.user = { id: userIdBigInt, providerId, socialType, email, profilePicture, nickname };
-
-      console.log(request.user);
 
       return true;
     } catch (error) {

--- a/app/backend/src/auth/interface/payload.interface.ts
+++ b/app/backend/src/auth/interface/payload.interface.ts
@@ -1,6 +1,10 @@
 import { JwtPayload } from 'jsonwebtoken';
 
 export interface Payload extends JwtPayload {
+  userId: bigint;
   providerId: string;
   socialType: string;
+  email: string;
+  profilePicture: string;
+  nickname: string;
 }

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GroupsService } from './groups.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
@@ -12,7 +12,6 @@ import { CreateGroupsDto } from './dto/create-groups.dto';
 @ApiTags('Group API')
 @Controller('groups')
 @UseGuards(AtGuard)
-@ApiBearerAuth('access_token')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 

--- a/app/backend/src/member/member.controller.ts
+++ b/app/backend/src/member/member.controller.ts
@@ -1,14 +1,11 @@
 import { Request, Response } from 'express';
-import { Controller, Get, Req, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Req, Res, UnauthorizedException } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MemberService } from './member.service';
-import { AtGuard } from 'src/auth/guards/at.guard';
 import { MemberInformationDto } from './dto/member.dto';
 
 @ApiTags('Member Infomation API')
 @Controller('member')
-@UseGuards(AtGuard)
-@ApiBearerAuth('access_token')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 

--- a/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Query, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MogacoService } from './mogaco-boards.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
@@ -11,7 +11,6 @@ import { ParticipantResponseDto } from './dto/response-participants.dto';
 @ApiTags('Mogaco API')
 @Controller('posts')
 @UseGuards(AtGuard)
-@ApiBearerAuth('access_token')
 export class MogacoController {
   constructor(private readonly mogacoService: MogacoService) {}
 


### PR DESCRIPTION
## 설명
- close #406 

[개발 일지](https://ttaerrim.notion.site/Cookie-Httponly-Secure-ea27c771aeef406aadc02709f587c99e?pvs=4)
[회의 기록](https://ttaerrim.notion.site/930d97a2db1743d7bd61117fc9f23716?pvs=4)

프론트엔드는 API 요청을 할 때 헤더에 bearer token을 심어서 보낼 필요가 없습니다.
서버단에서 해당 요청한 사용자의 쿠키에서 액세스 토큰을 추출해내어 인가를 처리합니다.

이를 통해 클라이언트에서는 쿠키에 직접 접근할 필요가 없어지며, httponly를 걸어서 보안적으로도 이점을 취할 수 있습니다.

## 완료한 기능 명세
- [x] 로그인 인가 처리 방식 변경 (bearer token 사용 x)
- [x] httponly 설정

### 스크린샷
- 위의 개발일지, 회의 확인


## 리뷰 요청 사항
@ttaerrim @js43o @LEEJW1953 

위의 개발일지를 자세히 봐주시기 바랍니다.
