### PR TITLE
[Feature] 모각코 상세 글 지도 static map으로 변경

### DIFF
--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
@@ -8,7 +8,7 @@ import { ReactComponent as Calendar } from '@/assets/icons/calendar.svg';
 import { ReactComponent as Map } from '@/assets/icons/map.svg';
 import { ReactComponent as People } from '@/assets/icons/people.svg';
 import { Error, Loading, UserChip } from '@/components';
-import { useMap } from '@/hooks';
+import { TMAP_API_KEY, DEFAULT_ZOOM_LEVEL } from '@/constants';
 import { queryKeys } from '@/queries';
 import { vars } from '@/styles';
 
@@ -22,19 +22,6 @@ type DetailInfoProps = {
 
 export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
   const [participantsShown, setParticipantsShown] = useState(false);
-  const mapRef = useRef<HTMLDivElement>(null);
-  const { mapInstance, updateMarker } = useMap(mapRef);
-
-  useEffect(() => {
-    updateMarker({ latitude, longitude }, 'green');
-    mapInstance?.setOptions({
-      zoomControl: false,
-      draggable: false,
-      scrollwheel: false,
-      scaleBar: false,
-      pinchZoom: false,
-    });
-  }, [latitude, longitude, mapInstance, updateMarker]);
 
   const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery(
     queryKeys.mogaco.detail(id),
@@ -50,6 +37,10 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
   if (!mogacoData) {
     return <Error message="모각코 정보를 불러오지 못했습니다." />;
   }
+
+  const staticMapURL = `
+  https://apis.openapi.sk.com/tmap/staticMap?appKey=${TMAP_API_KEY}&longitude=${longitude}&latitude=${latitude}&zoom=${DEFAULT_ZOOM_LEVEL}&markers=pin-m@1FAB70(${longitude},${latitude})viewSize:0.6
+  `;
 
   return (
     <div className={styles.info}>
@@ -90,7 +81,11 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
         <Map width={24} height={24} fill={vars.color.grayscale200} />
         <span>{mogacoData.address}</span>
       </div>
-      <div id="map" className={styles.map} ref={mapRef} />
+      <img
+        className={styles.map}
+        src={staticMapURL}
+        alt={`${mogacoData.title} 지도 이미지`}
+      />
     </div>
   );
 }

--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -27,7 +27,13 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
 
   useEffect(() => {
     updateMarker({ latitude, longitude }, 'green');
-    mapInstance?.setOptions({ zoomControl: false });
+    mapInstance?.setOptions({
+      zoomControl: false,
+      draggable: false,
+      scrollwheel: false,
+      scaleBar: false,
+      pinchZoom: false,
+    });
   }, [latitude, longitude, mapInstance, updateMarker]);
 
   const { data: mogacoData, isLoading: mogacoDataLoading } = useQuery(

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -1,9 +1,5 @@
 export type MapOptions = {
   zoomControl?: boolean;
-  draggable?: boolean;
-  scrollwheel?: boolean;
-  scaleBar?: boolean;
-  pinchZoom?: boolean;
 };
 
 export type NewAddress = {
@@ -42,13 +38,7 @@ export type TMap = {
   setCenter: (latLng: TMapLatLng) => void;
   setZoomLimit: (minZoom: number, maxZoom: number) => void;
   setZoom: (zoomLevel: number) => void;
-  setOptions: ({
-    zoomControl,
-    draggable,
-    scrollwheel,
-    scaleBar,
-    pinchZoom,
-  }: MapOptions) => void;
+  setOptions: ({ zoomControl }: MapOptions) => void;
   destroy: () => void;
   addListener: (
     eventType: EventType,

--- a/app/frontend/src/types/tmap.ts
+++ b/app/frontend/src/types/tmap.ts
@@ -1,5 +1,9 @@
 export type MapOptions = {
   zoomControl?: boolean;
+  draggable?: boolean;
+  scrollwheel?: boolean;
+  scaleBar?: boolean;
+  pinchZoom?: boolean;
 };
 
 export type NewAddress = {
@@ -38,7 +42,13 @@ export type TMap = {
   setCenter: (latLng: TMapLatLng) => void;
   setZoomLimit: (minZoom: number, maxZoom: number) => void;
   setZoom: (zoomLevel: number) => void;
-  setOptions: ({ zoomControl }: MapOptions) => void;
+  setOptions: ({
+    zoomControl,
+    draggable,
+    scrollwheel,
+    scaleBar,
+    pinchZoom,
+  }: MapOptions) => void;
   destroy: () => void;
   addListener: (
     eventType: EventType,


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- close #387
- 모각코 상세 글 지도 static map으로 변경
- 상세 페이지에서 움직일 수 있는 지도를 사용하는 것은 지도 api를 통한 네트워크 요청 면에서 오버스펙이라고 생각하여 static map으로 변경하였습니다.

## 완료한 기능 명세
- [x] 모각코 상세 글 지도 static map으로 변경

### 스크린샷

![image](https://github.com/boostcampwm2023/web17_morak/assets/110762136/3642958d-1225-4f65-9fd7-d20b40765c73)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

