### PR TITLE
[Fix] 새로운 채팅 참여자에 대한 정보를 동적으로 리페칭하도록 변경

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
@@ -74,8 +74,8 @@ export function ChatList({
         return chatItem.messageType === 'talk' ? (
           <MemorizedTalkItem
             key={chatItem.date.toString()}
-            nickname={participantInfo?.nickname || ''}
-            profilePicture={participantInfo?.profilePicture || ''}
+            nickname={participantInfo?.nickname}
+            profilePicture={participantInfo?.profilePicture}
             contents={chatItem.contents}
             date={chatItem.date}
             isMine={chatItem.user === userId}

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/TalkItem.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/TalkItem.tsx
@@ -7,8 +7,8 @@ import { UserChip } from '@/components';
 import * as styles from './ChatItem.css';
 
 type TalkItemProps = {
-  nickname: string;
-  profilePicture: string;
+  nickname?: string;
+  profilePicture?: string;
   contents: string;
   date: Date;
   isMine: boolean;

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/index.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/index.tsx
@@ -57,6 +57,7 @@ export function Chatting({
         participatedRef.current.nickname,
         participatedRef.current.id,
       );
+      leaveRoom();
       resetChatItems();
       participatedRef.current = undefined;
     }
@@ -72,13 +73,7 @@ export function Chatting({
     leaveRoom,
   ]);
 
-  useEffect(() => {
-    if (!userData) {
-      return;
-    }
-
-    return () => leaveRoom(userData.id);
-  }, [userData, leaveRoom]);
+  useEffect(() => () => leaveRoom(), [leaveRoom]);
 
   if (!userData) {
     return (

--- a/app/frontend/src/components/UserChip/index.css.ts
+++ b/app/frontend/src/components/UserChip/index.css.ts
@@ -35,3 +35,7 @@ export const profileImage = style({
   borderRadius: '50%',
   overflow: 'hidden',
 });
+
+export const unknown = style({
+  color: vars.color.grayscale200,
+});

--- a/app/frontend/src/components/UserChip/index.tsx
+++ b/app/frontend/src/components/UserChip/index.tsx
@@ -4,7 +4,7 @@ import { vars } from '@/styles';
 import * as styles from './index.css';
 
 type UserChipProps = {
-  username: string;
+  username?: string;
   profileSrc?: string;
 };
 
@@ -22,7 +22,9 @@ export function UserChip({ username, profileSrc }: UserChipProps) {
           <Profile width={24} height={24} fill={vars.color.morakGreen} />
         )}
       </div>
-      <span className={styles.nickname}>{username}</span>
+      <span className={`${styles.nickname} ${!username && styles.unknown}`}>
+        {username || '(알 수 없음)'}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## 설명
- close #383 
- 채팅 도중 새로운 사용자가 입장/퇴장할 때마다 모각코 정보를 동적으로 페칭하여 참여자 정보를 불러옵니다. (닉네임 및 프로필 사진이 정상적으로 표시되지 않던 버그 수정)
- useChatting 훅에서 현재 사용자 ID를 기억하기 위한 `userIdRef` 변수를 선언했고, `joinRoom()` 및 `leaveRoom()`이 `userIdRef`를 조건으로 동작하도록 변경하였습니다.
- 기존 모각코 참여자가 참석 취소를 하여 퇴장한 경우 '알 수 없음'으로 표시하도록 하였습니다. (다시 참석하면 기존 '알 수 없음' 정보가 다시 제대로 표시됩니다)

## 완료한 기능 명세
- [x] joinRoom() 및 leaveRoom()이 불필요하게 호출되지 않도록 개선
- [x] 입장/퇴장 알림 메시지 수신 시 모각코 게시글에 대한 쿼리 무효화 함수 호출 (정보 리페칭)
- [x] 알 수 없는 사용자 전용 스타일 추가

### 동작 화면
https://github.com/boostcampwm2023/web17_morak/assets/50646827/cdeb6e88-b3ba-4604-823c-e596a1567909

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

