### PR TITLE
[Design] 프로필 페이지 내가 속한 그룹 스타일 수정

### DIFF
--- a/app/frontend/src/pages/Profile/index.css.ts
+++ b/app/frontend/src/pages/Profile/index.css.ts
@@ -12,6 +12,7 @@ export const list = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1.6rem',
+  minHeight: '1.8rem',
   maxHeight: '48rem',
   overflowY: 'auto',
 });


### PR DESCRIPTION
그룹이 없을 경우 발생하는 스크롤 바 제거

<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- 내가 속한 그룹이 없을 경우 스크롤 바 발생
- 최소 높이를 지정하여 스크롤 바를 없앴습니다.

## 완료한 기능 명세
- [x] 프로필 페이지 내가 속한 그룹 스타일 수정

### 스크린샷
- 전
![image](https://github.com/boostcampwm2023/web17_morak/assets/110762136/059b577a-b0b4-4802-81b5-667084abff25)

- 후
![image](https://github.com/boostcampwm2023/web17_morak/assets/110762136/b5a36c8a-a36f-43b3-b5c0-41353de724d6)


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

