### PR TITLE
[Feat] 마이페이지 - 내가 참가한 모각코 추가

### DIFF
--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -11,7 +11,13 @@ import * as styles from './index.css';
 
 type MogacoProps = Omit<
   ResponseMogacoDto,
-  'createdAt' | 'deletedAt' | 'updatedAt' | 'latitude' | 'longitude'
+  | 'createdAt'
+  | 'deletedAt'
+  | 'updatedAt'
+  | 'latitude'
+  | 'longitude'
+  | 'groupId'
+  | 'maxHumanCount'
 >;
 
 export function MogacoItem({

--- a/app/frontend/src/pages/Profile/MyGroup/index.css.ts
+++ b/app/frontend/src/pages/Profile/MyGroup/index.css.ts
@@ -1,37 +1,11 @@
 import { style } from '@vanilla-extract/css';
 
-import { vars } from '@/styles';
-import { sansBold16 } from '@/styles/font.css';
-
 import * as parentStyle from '../index.css';
 
 export const groupButtons = style({
   display: 'flex',
   gap: '1.2rem',
 });
-export const groupListButton = style([
-  sansBold16,
-  {
-    display: 'flex',
-    gap: 0,
-    alignItems: 'center',
-    alignSelf: 'end',
-    color: vars.color.morakGreen,
-  },
-]);
 
-export const loading = style({
-  width: '100%',
-  display: 'flex',
-  justifyContent: 'center',
-});
-
-export const navLink = style({
-  width: '100%',
-});
-
-export const rotateArrow = style({
-  transform: 'rotate(180deg)',
-});
-
-export const { section, list } = parentStyle;
+export const { section, list, loading, navLinkButton, rotateArrow } =
+  parentStyle;

--- a/app/frontend/src/pages/Profile/MyGroup/index.tsx
+++ b/app/frontend/src/pages/Profile/MyGroup/index.tsx
@@ -40,7 +40,7 @@ export function MyGroup() {
           <Error message="현재 속한 그룹이 없습니다. 그룹에 참여해 주세요." />
         )}
       </ul>
-      <NavLink to="/groups" className={styles.groupListButton}>
+      <NavLink to="/groups" className={styles.navLinkButton}>
         <ArrowLeft
           fill={vars.color.morakGreen}
           width={24}

--- a/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
@@ -1,0 +1,21 @@
+import { style } from '@vanilla-extract/css';
+
+import { sansRegular16 } from '@/styles/font.css';
+
+import * as parentStyle from '../index.css';
+
+export const { section, list } = parentStyle;
+
+export const loading = style({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+});
+
+export const notParticipated = style([
+  sansRegular16,
+  {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+]);

--- a/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
@@ -1,28 +1,12 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
-import { sansBold16, sansRegular16 } from '@/styles/font.css';
+import { sansRegular16 } from '@/styles/font.css';
 
 import * as parentStyle from '../index.css';
 
-export const { section, list } = parentStyle;
-
-export const loading = style({
-  width: '100%',
-  display: 'flex',
-  justifyContent: 'center',
-});
-
-export const mogacoListButton = style([
-  sansBold16,
-  {
-    display: 'flex',
-    gap: 0,
-    alignItems: 'center',
-    alignSelf: 'end',
-    color: vars.color.morakGreen,
-  },
-]);
+export const { section, list, loading, navLinkButton, rotateArrow } =
+  parentStyle;
 
 export const notParticipated = style([
   sansRegular16,
@@ -33,7 +17,3 @@ export const notParticipated = style([
     color: vars.color.grayscale200,
   },
 ]);
-
-export const rotateArrow = style({
-  transform: 'rotate(180deg)',
-});

--- a/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
-import { sansRegular16 } from '@/styles/font.css';
+import { vars } from '@/styles';
+import { sansBold16, sansRegular16 } from '@/styles/font.css';
 
 import * as parentStyle from '../index.css';
 
@@ -12,10 +13,27 @@ export const loading = style({
   justifyContent: 'center',
 });
 
+export const mogacoListButton = style([
+  sansBold16,
+  {
+    display: 'flex',
+    gap: 0,
+    alignItems: 'center',
+    alignSelf: 'end',
+    color: vars.color.morakGreen,
+  },
+]);
+
 export const notParticipated = style([
   sansRegular16,
   {
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
+    color: vars.color.grayscale200,
   },
 ]);
+
+export const rotateArrow = style({
+  transform: 'rotate(180deg)',
+});

--- a/app/frontend/src/pages/Profile/MyMogaco/index.tsx
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.tsx
@@ -50,7 +50,7 @@ export function MyMogaco() {
           ) : (
             <div className={styles.notParticipated}>
               <span>현재 참가한 모각코가 없습니다.</span>
-              <NavLink to="/mogaco" className={styles.mogacoListButton}>
+              <NavLink to="/mogaco" className={styles.navLinkButton}>
                 <ArrowLeft
                   fill={vars.color.morakGreen}
                   width={24}

--- a/app/frontend/src/pages/Profile/MyMogaco/index.tsx
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.tsx
@@ -1,6 +1,9 @@
+import { NavLink } from 'react-router-dom';
+
 import { useQuery } from '@tanstack/react-query';
 
-import { Button, Error, LoadingIndicator, MogacoItem } from '@/components';
+import { ReactComponent as ArrowLeft } from '@/assets/icons/arrow_left.svg';
+import { Error, LoadingIndicator, MogacoItem } from '@/components';
 import { queryKeys } from '@/queries';
 import { vars } from '@/styles';
 import { sansBold24 } from '@/styles/font.css';
@@ -46,10 +49,16 @@ export function MyMogaco() {
             )
           ) : (
             <div className={styles.notParticipated}>
-              <span>참여한 모각코가 없습니다. 참여해 보세요!</span>
-              <Button theme="primary" shape="text" size="large">
-                바로가기
-              </Button>
+              <span>현재 참가한 모각코가 없습니다.</span>
+              <NavLink to="/mogaco" className={styles.mogacoListButton}>
+                <ArrowLeft
+                  fill={vars.color.morakGreen}
+                  width={24}
+                  height={24}
+                  className={styles.rotateArrow}
+                />
+                둘러보기
+              </NavLink>
             </div>
           ))}
       </ul>

--- a/app/frontend/src/pages/Profile/MyMogaco/index.tsx
+++ b/app/frontend/src/pages/Profile/MyMogaco/index.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Button, Error, LoadingIndicator, MogacoItem } from '@/components';
+import { queryKeys } from '@/queries';
+import { vars } from '@/styles';
+import { sansBold24 } from '@/styles/font.css';
+
+import * as styles from './index.css';
+
+export function MyMogaco() {
+  const {
+    data: mogacoList,
+    isLoading,
+    isError,
+  } = useQuery(queryKeys.mogaco.myMogaco());
+
+  return (
+    <section className={styles.section}>
+      <div className={sansBold24}>현재 참가한 모각코</div>
+      <ul className={styles.list}>
+        {isLoading && (
+          <LoadingIndicator
+            color={vars.color.grayscale500}
+            size={30}
+            className={styles.loading}
+          />
+        )}
+        {isError && (
+          <Error message="참여한 모각코 정보를 불러오지 못했습니다." />
+        )}
+        {mogacoList &&
+          (mogacoList.length > 0 ? (
+            mogacoList.map(
+              ({ id, status, title, group, contents, address, date }) => (
+                <MogacoItem
+                  key={id}
+                  id={id}
+                  status={status}
+                  title={title}
+                  group={group}
+                  contents={contents}
+                  address={address}
+                  date={date}
+                />
+              ),
+            )
+          ) : (
+            <div className={styles.notParticipated}>
+              <span>참여한 모각코가 없습니다. 참여해 보세요!</span>
+              <Button theme="primary" shape="text" size="large">
+                바로가기
+              </Button>
+            </div>
+          ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/frontend/src/pages/Profile/index.css.ts
+++ b/app/frontend/src/pages/Profile/index.css.ts
@@ -1,5 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
+import { vars } from '@/styles';
+import { sansBold16 } from '@/styles/font.css';
+
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -14,6 +17,27 @@ export const list = style({
   gap: '1.6rem',
   maxHeight: '48rem',
   overflowY: 'auto',
+});
+
+export const loading = style({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+});
+
+export const navLinkButton = style([
+  sansBold16,
+  {
+    display: 'flex',
+    gap: 0,
+    alignItems: 'center',
+    alignSelf: 'end',
+    color: vars.color.morakGreen,
+  },
+]);
+
+export const rotateArrow = style({
+  transform: 'rotate(180deg)',
 });
 
 export const section = style({

--- a/app/frontend/src/pages/Profile/index.tsx
+++ b/app/frontend/src/pages/Profile/index.tsx
@@ -1,8 +1,8 @@
 import { Divider } from '@/components';
-import { sansBold24 } from '@/styles/font.css';
 
 import * as styles from './index.css';
 import { MyGroup } from './MyGroup';
+import { MyMogaco } from './MyMogaco';
 import { MyProfile } from './MyProfile';
 
 export function ProfilePage() {
@@ -10,10 +10,7 @@ export function ProfilePage() {
     <div className={styles.container}>
       <MyProfile />
       <Divider />
-      <section className={styles.section}>
-        <div className={sansBold24}>현재 참가한 모각코</div>
-        <ul className={styles.list}>{/* <MogacoItem /> */}</ul>
-      </section>
+      <MyMogaco />
       <MyGroup />
     </div>
   );

--- a/app/frontend/src/queries/mogaco.ts
+++ b/app/frontend/src/queries/mogaco.ts
@@ -11,4 +11,8 @@ export const mogacoKeys = createQueryKeys('mogaco', {
     queryKey: [id],
     queryFn: () => mogaco.detail(id),
   }),
+  myMogaco: () => ({
+    queryKey: ['myMogaco'],
+    queryFn: () => mogaco.myMogaco(),
+  }),
 });

--- a/app/frontend/src/services/mogaco.ts
+++ b/app/frontend/src/services/mogaco.ts
@@ -46,4 +46,10 @@ export const mogaco = {
     );
     return response;
   },
+  myMogaco: async () => {
+    const { data } = await morakAPI.get<ResponseMogacoDto[]>(
+      `${mogaco.endPoint.default}/my-mogacos`,
+    );
+    return data;
+  },
 };


### PR DESCRIPTION
## 설명
- close #328 
- 현재 로그인한 사용자가 참여한 모각코 목록을 마이페이지에서 불러와 표시합니다.
- `<MyGroup>` 컴포넌트와 사용하는 스타일이 많이 겹쳐서 공통 스타일을 `index.css.ts`로 이동하였습니다.

## 완료한 기능 명세
- [x] GET /posts/my-mogacos API 함수 및 쿼리 키 추가
- [x] 내가 참가한 모각코 컴포넌트 추가

### 스크린샷
- 참여한 모각코 있음 (3개 이상부터 스크롤 처리)
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/0db2acd3-0ec4-4772-9768-fdb479f779b8)

- 참여한 모각코 없음
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/c0f7bd79-6987-4d77-a1e5-d177e048fdcd)

- 데이터 페칭 에러
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/4ef7b5f5-afa7-465d-a9c7-6372a3df9aa6)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

