### PR TITLE
[Refactor] 본인이 참여한 모각코 조회 API 수정

### DIFF
--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -170,37 +170,36 @@ export class MogacoRepository {
   }
 
   async getMyMogacos(member: Member): Promise<MogacoDto[]> {
-    const userGroupIds = await this.getUserGroupIds(member);
-
-    const mogacos = await this.prisma.mogaco.findMany({
+    const mogacos = await this.prisma.participant.findMany({
       where: {
-        deletedAt: null,
-        groupId: {
-          in: userGroupIds,
-        },
+        userId: member.id,
       },
       include: {
-        group: true,
+        mogaco: {
+          include: {
+            group: true,
+          },
+        },
       },
     });
 
-    const mappedMogacos = mogacos.map((mogaco) => ({
-      id: mogaco.id.toString(),
-      groupId: mogaco.group.id.toString(),
-      title: mogaco.title,
-      contents: mogaco.contents,
-      date: mogaco.date,
-      maxHumanCount: mogaco.maxHumanCount,
-      address: mogaco.address,
-      latitude: Number(mogaco.latitude),
-      longitude: Number(mogaco.longitude),
-      status: mogaco.status,
-      createdAt: mogaco.createdAt,
-      updatedAt: mogaco.updatedAt,
-      deletedAt: mogaco.deletedAt,
+    const mappedMogacos = mogacos.map((participant) => ({
+      id: participant.mogaco.id.toString(),
+      groupId: participant.mogaco.group.id.toString(),
+      title: participant.mogaco.title,
+      contents: participant.mogaco.contents,
+      date: participant.mogaco.date,
+      maxHumanCount: participant.mogaco.maxHumanCount,
+      address: participant.mogaco.address,
+      latitude: Number(participant.mogaco.latitude),
+      longitude: Number(participant.mogaco.longitude),
+      status: participant.mogaco.status,
+      createdAt: participant.mogaco.createdAt,
+      updatedAt: participant.mogaco.updatedAt,
+      deletedAt: participant.mogaco.deletedAt,
       group: {
-        id: mogaco.group.id.toString(),
-        title: mogaco.group.title,
+        id: participant.mogaco.group.id.toString(),
+        title: participant.mogaco.group.title,
       },
     }));
 


### PR DESCRIPTION
## 설명
본인이 속한 모각코 조회가 본인이 속한 그룹의 모각코를 불러오는 것으로 잘못되어 수정합니다.

## 완료한 기능 명세
- [x] 본인이 참여한 모각코 조회 API 수정

### 스크린샷
<img width="819" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/789bedc1-7f52-4757-a4a6-64407e776030">

- 현재 이 계정은 14번 하나만 참여함
<img width="197" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/42c981b8-7e7a-413a-bd39-ac10df88aadc">



## 리뷰 요청 사항
@js43o 

