### PR TITLE
[Fix] 맥 환경에서 채팅 마지막 글자가 중복 전송되는 현상 수정

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Chatting/ChattingFooter.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/ChattingFooter.tsx
@@ -29,7 +29,7 @@ export function ChattingFooter({ userId, sendMessage }: ChattingFooterProps) {
   };
 
   const onKeydownTextarea = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSendMessage();
     }


### PR DESCRIPTION
## 설명
- close #381 
- 맥 환경에서 전송한 한글 채팅 메시지의 마지막 글자가 중복으로 한 번 더 전송되는 현상을 막기 위해 `e.nativeEvent.isComposing` 속성을 전송 핸들러의 조건문에 추가하였습니다.

## 완료한 기능 명세
- [x] 채팅 전송 키보드 이벤트 핸들러 조건문 수정

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

## 리뷰 요청 사항
- 맥 OS를 사용하시는 분들께 테스트를 부탁드립니다🥹
```
git fetch upstream refs/pull/426/head:test
git switch test
```
