### PR TITLE
[fix] backend Dockerfile DB ip 유동성 추가

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -59,4 +59,4 @@ RUN chmod +x /docker-entrypoint.sh
 RUN sed -i 's/\r//' /wait-for-it.sh
 RUN sed -i 's/\r//' /docker-entrypoint.sh
 
-CMD ["/wait-for-it.sh", "db:3306", "--", "/docker-entrypoint.sh"]
+CMD ["/wait-for-it.sh", "--", "/docker-entrypoint.sh"]

--- a/app/backend/wait-for-it.sh
+++ b/app/backend/wait-for-it.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 set -e
 
-host=$(echo $1 | cut -d ':' -f 1)
-port=$(echo $1 | cut -d ':' -f 2)
-shift
+host=$(echo $DATABASE_URL | sed -e 's|^[^@]*@||' -e 's|:[^:]*$||')
+port=$(echo $DATABASE_URL | sed -e 's|^.*:||' -e 's|/.*$||')
 
 cmd="$@"
 
@@ -14,4 +13,3 @@ done
 
 >&2 echo "MySQL is up - executing command"
 exec $cmd
-


### PR DESCRIPTION
## 설명
- 현재 구조는 DB host의 주소가 DB로만 이루어져 있을 때 동작하였지만, 환경 변수에 따라 유동적으로 처리 되게 변경

