### PR TITLE
[Fix] 사이드바 내용 overflow 수정

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/MogacoInfo.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/MogacoInfo.tsx
@@ -1,7 +1,6 @@
 import { ResponseMogacoWithMemberDto } from '@morak/apitype';
 
 import { Button } from '@/components';
-import { sansRegular16 } from '@/styles/font.css';
 
 import { GroupWrapper } from './GroupWrapper';
 import * as styles from './index.css';
@@ -38,7 +37,7 @@ export function MogacoInfo({
           maxHumanCount={maxHumanCount}
           address={address}
         />
-        <p className={sansRegular16}>{contents}</p>
+        <p className={styles.contents}>{contents}</p>
       </div>
       <Button
         fullWidth

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/index.css.ts
@@ -1,7 +1,12 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
-import { sansBold16, sansBold24, sansRegular14 } from '@/styles/font.css';
+import {
+  sansBold16,
+  sansBold24,
+  sansRegular14,
+  sansRegular16,
+} from '@/styles/font.css';
 
 export const container = style({
   display: 'flex',
@@ -11,6 +16,14 @@ export const container = style({
   color: vars.color.grayscaleBlack,
   padding: '2rem',
 });
+
+export const contents = style([
+  sansRegular16,
+  {
+    lineHeight: 1.4,
+    wordBreak: 'break-all',
+  },
+]);
 
 export const group = style([
   sansBold16,


### PR DESCRIPTION
## 설명
- close #425
- 사이드바의 contents 영역의 글자가 줄바꿈되지 않아 넘치는 현상을 수정합니다.

## 완료한 기능 명세
- [x] 사이드바 contents 스타일 지정

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/f059a174-591a-4e7f-bb49-74723d0fa0cc)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

