### PR TITLE
[Fix] 모각코 상세 게시글 페이지 contents 줄바꿈 개선

### DIFF
--- a/app/frontend/src/components/Button/moreButton.css.ts
+++ b/app/frontend/src/components/Button/moreButton.css.ts
@@ -31,7 +31,7 @@ export const dropdown = style({
 export const dropdownButton = style([
   sansRegular16,
   {
-    padding: '1rem',
+    padding: '0.8rem',
     width: '100%',
     whiteSpace: 'nowrap',
 
@@ -57,7 +57,7 @@ export const dropdownItem = style({
 export const moreButton = style({
   display: 'flex',
   borderRadius: '50%',
-  padding: '1rem',
+  padding: '0.8rem',
 
   ':hover': {
     background: vars.color.grayscale50,

--- a/app/frontend/src/pages/MogacoDetail/index.css.ts
+++ b/app/frontend/src/pages/MogacoDetail/index.css.ts
@@ -1,7 +1,12 @@
 import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/styles';
-import { sansBold16, sansBold24, sansRegular16 } from '@/styles/font.css';
+import {
+  sansBold16,
+  sansBold24,
+  sansRegular14,
+  sansRegular16,
+} from '@/styles/font.css';
 
 export const buttons = style({
   display: 'flex',
@@ -17,6 +22,13 @@ export const container = style([
     width: '100%',
     maxWidth: '80rem',
     lineHeight: '1.6',
+  },
+]);
+
+export const contents = style([
+  sansRegular14,
+  {
+    wordBreak: 'break-all',
   },
 ]);
 

--- a/app/frontend/src/pages/MogacoDetail/index.tsx
+++ b/app/frontend/src/pages/MogacoDetail/index.tsx
@@ -6,7 +6,6 @@ import { useQuery } from '@tanstack/react-query';
 import { ChattingSidebar, Divider, Error, Loading } from '@/components';
 import { queryKeys } from '@/queries';
 import { vars } from '@/styles';
-import { sansRegular14 } from '@/styles/font.css';
 
 import { DetailHeader } from './DetailHeader';
 import { DetailInfo } from './DetailInfo';
@@ -59,7 +58,7 @@ export function MogacoDetailPage() {
           latitude={mogacoData.latitude}
           longitude={mogacoData.longitude}
         />
-        <div className={sansRegular14}>{mogacoData.contents}</div>
+        <div className={styles.contents}>{mogacoData.contents}</div>
         <Divider />
       </div>
     </div>


### PR DESCRIPTION
## 설명
- close #432 
- 모각코 상세 게시글 페이지에서 contents 영역의 줄바꿈이 제대로 되지 않아 텍스트가 넘치는 현상을 수정합니다.

## 완료한 기능 명세
- [x] contents 스타일 작성 및 줄바꿈 처리
- [x] 더보기 버튼 padding 조정

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/f7ed00ae-bb18-4f2d-aab2-528ef4b08e66)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

