### PR TITLE
[Test] Main 페이지 로그인/비로그인 테스트 코드 작성

### DIFF
--- a/app/frontend/cypress.config.ts
+++ b/app/frontend/cypress.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from "cypress";
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
+    baseUrl: 'http://localhost:5173',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/app/frontend/cypress.config.ts
+++ b/app/frontend/cypress.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+  env: {
+    ACCESS_TOKEN: '',
+  },
 });

--- a/app/frontend/cypress.config.ts
+++ b/app/frontend/cypress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   env: {
+    // ACCESS_TOKEN을 넣은 채로 커밋하지 않도록 주의
     ACCESS_TOKEN: '',
   },
 });

--- a/app/frontend/cypress/e2e/login.cy.ts
+++ b/app/frontend/cypress/e2e/login.cy.ts
@@ -15,13 +15,16 @@ describe('메인 페이지 비로그인 테스트', () => {
 describe('메인 페이지 로그인 테스트', () => {
   beforeEach(() => {
     cy.clearCookie('access_token');
+    // 테스트 실패 시 cypress.config.ts에 ACCESS_TOKEN이 있는지 확인 필요
     cy.setCookie('access_token', Cypress.env('ACCESS_TOKEN'));
     cy.viewport('macbook-13');
     cy.visit('/');
   });
+
   it('로그인한 상태에서는 메인 페이지에 로그인 버튼이 보이지 않아야 한다.', () => {
     cy.get('[data-cy="login-button"]').should('be.empty');
   });
+
   it('로그인한 상태에서 첫 번째 메뉴를 클릭했을 경우 해당 라우터로 넘어간다', () => {
     cy.get('[data-cy="header-menu-item"]').first().click();
     cy.get('[data-cy="header-menu-item"]')

--- a/app/frontend/cypress/e2e/login.cy.ts
+++ b/app/frontend/cypress/e2e/login.cy.ts
@@ -8,5 +8,6 @@ describe('메인 페이지 비로그인 테스트', () => {
         cy.get('dialog').find('button').click();
       },
     );
+    cy.get('[data-cy="login-button"] > button').should('be.visible');
   });
 });

--- a/app/frontend/cypress/e2e/login.cy.ts
+++ b/app/frontend/cypress/e2e/login.cy.ts
@@ -1,0 +1,12 @@
+describe('메인 페이지 비로그인 테스트', () => {
+  it('로그인하지 않고 메뉴를 클릭했을 경우 로그인 필요 모달이 떠야 한다', () => {
+    cy.viewport('macbook-13');
+    cy.visit('/');
+    cy.get('[data-cy="header-menu"] > [data-cy="header-menu-item"]').each(
+      ($li) => {
+        cy.wrap($li).click().wait(100);
+        cy.get('dialog').find('button').click();
+      },
+    );
+  });
+});

--- a/app/frontend/cypress/e2e/login.cy.ts
+++ b/app/frontend/cypress/e2e/login.cy.ts
@@ -11,3 +11,23 @@ describe('메인 페이지 비로그인 테스트', () => {
     cy.get('[data-cy="login-button"] > button').should('be.visible');
   });
 });
+
+describe('메인 페이지 로그인 테스트', () => {
+  beforeEach(() => {
+    cy.clearCookie('access_token');
+    cy.setCookie('access_token', Cypress.env('ACCESS_TOKEN'));
+    cy.viewport('macbook-13');
+    cy.visit('/');
+  });
+  it('로그인한 상태에서는 메인 페이지에 로그인 버튼이 보이지 않아야 한다.', () => {
+    cy.get('[data-cy="login-button"]').should('be.empty');
+  });
+  it('로그인한 상태에서 첫 번째 메뉴를 클릭했을 경우 해당 라우터로 넘어간다', () => {
+    cy.get('[data-cy="header-menu-item"]').first().click();
+    cy.get('[data-cy="header-menu-item"]')
+      .first()
+      .should('have.css', 'font-weight')
+      .and('match', /700/);
+    cy.url().should('include', '/mogaco');
+  });
+});

--- a/app/frontend/cypress/e2e/login.cy.ts
+++ b/app/frontend/cypress/e2e/login.cy.ts
@@ -1,13 +1,19 @@
 describe('메인 페이지 비로그인 테스트', () => {
-  it('로그인하지 않고 메뉴를 클릭했을 경우 로그인 필요 모달이 떠야 한다', () => {
+  beforeEach(() => {
+    cy.clearCookie('access_token');
     cy.viewport('macbook-13');
     cy.visit('/');
+  });
+
+  it('로그인하지 않고 메뉴를 클릭했을 경우 로그인 필요 모달이 떠야 한다', () => {
+    cy.clearCookie('access_token');
     cy.get('[data-cy="header-menu"] > [data-cy="header-menu-item"]').each(
       ($li) => {
         cy.wrap($li).click().wait(100);
         cy.get('dialog').find('button').click();
       },
     );
+    cy.url().should('eq', Cypress.config().baseUrl + '/');
     cy.get('[data-cy="login-button"] > button').should('be.visible');
   });
 });

--- a/app/frontend/cypress/e2e/spec.cy.ts
+++ b/app/frontend/cypress/e2e/spec.cy.ts
@@ -1,5 +1,0 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -19,7 +19,7 @@ export function Header() {
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
-        <ul className={styles.sideMenu}>
+        <ul className={styles.sideMenu} data-cy="header-menu">
           {SIDE_MENU.map((menu) => (
             <li
               role="menuitem"
@@ -29,6 +29,7 @@ export function Header() {
               className={`${styles.sideMenuButton} ${
                 pathname === `/${menu.pathname}` ? styles.active : ''
               }`}
+              data-cy="header-menu-item"
             >
               {menu.value}
             </li>

--- a/app/frontend/src/pages/Main/index.tsx
+++ b/app/frontend/src/pages/Main/index.tsx
@@ -22,7 +22,7 @@ export function MainPage() {
           <br />
           모락과 함께하세요
         </div>
-        <div className={styles.login}>
+        <div className={styles.login} data-cy="login-button">
           {!isLogin && (
             <Button
               type="button"


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- #440 
- 로그인/비로그인 시 메인 페이지에서 다른 페이지에 접근하는 e2e 테스트 작성
- 로그인 시 테스트는 cypress.config.ts 파일의 `ACCESS_TOKEN`에 토큰을 직접 넣어 실행해야 함. 
  - CI는 어떻게 할지 고민이네요 
    ```typescript
    import { defineConfig } from 'cypress';
    
    export default defineConfig({
      e2e: {
        baseUrl: 'http://localhost:5173',
        setupNodeEvents(on, config) {
          // implement node event listeners here
        },
      },
      env: {
        ACCESS_TOKEN: '', // 여기에 토큰 필요
      },
    });
    
    ```
- 테스트가 필요한 html tag에 `data-cy=""` 속성을 추가함. 
  - 추후 빌드 시 data-cy를 뺄 수 있는 방법이 있는지 찾아보면 좋을 듯.
 
## 완료한 기능 명세
- [x] e2e test 작성 

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="742" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/43867711/70f24adf-37f7-4501-bdb8-bdc46ee5f3d8">

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

