### PR TITLE
[Refactor] 헤더 및 모각코 리스트 페이지 접근성 개선

### DIFF
--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -19,22 +19,24 @@ export function Header() {
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
-        <ul className={styles.sideMenu} role="menubar">
-          {SIDE_MENU.map((menu) => (
-            <li
-              key={menu.pathname}
-              onClick={() => onClickMenu(menu.pathname)}
-              onKeyDown={() => onClickMenu(menu.pathname)}
-              className={`${styles.sideMenuButton} ${
-                pathname === `/${menu.pathname}` ? styles.active : ''
-              }`}
-              role="menuitem"
-              aria-label={menu.pathname}
-            >
-              {menu.value}
-            </li>
-          ))}
-        </ul>
+        <nav>
+          <ul className={styles.sideMenu} role="menubar">
+            {SIDE_MENU.map((menu) => (
+              <li
+                key={menu.pathname}
+                onClick={() => onClickMenu(menu.pathname)}
+                onKeyDown={() => onClickMenu(menu.pathname)}
+                className={`${styles.sideMenuButton} ${
+                  pathname === `/${menu.pathname}` ? styles.active : ''
+                }`}
+                role="menuitem"
+                aria-label={menu.pathname}
+              >
+                {menu.value}
+              </li>
+            ))}
+          </ul>
+        </nav>
       </div>
     </div>
   );

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -19,16 +19,17 @@ export function Header() {
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
-        <ul className={styles.sideMenu}>
+        <ul className={styles.sideMenu} role="menubar">
           {SIDE_MENU.map((menu) => (
             <li
-              role="menuitem"
               key={menu.pathname}
               onClick={() => onClickMenu(menu.pathname)}
               onKeyDown={() => onClickMenu(menu.pathname)}
               className={`${styles.sideMenuButton} ${
                 pathname === `/${menu.pathname}` ? styles.active : ''
               }`}
+              role="menuitem"
+              aria-label={menu.pathname}
             >
               {menu.value}
             </li>

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -13,7 +13,7 @@ export function Header() {
   const { onClickMenu } = useClickMenu();
 
   return (
-    <div className={styles.container}>
+    <header className={styles.container}>
       <div className={styles.header}>
         <NavLink to="/" className={styles.title}>
           <Logo className={styles.logo} />
@@ -38,6 +38,6 @@ export function Header() {
           </ul>
         </nav>
       </div>
-    </div>
+    </header>
   );
 }

--- a/app/frontend/src/components/Pagination/index.tsx
+++ b/app/frontend/src/components/Pagination/index.tsx
@@ -31,7 +31,12 @@ export function Pagination({
 
   return (
     <div className={`${styles.container} ${className}`}>
-      <button type="button" onClick={onClickPrev} disabled={isFirstPage}>
+      <button
+        type="button"
+        onClick={onClickPrev}
+        disabled={isFirstPage}
+        aria-label="prev-page"
+      >
         {arrow}
       </button>
       {array.map((page) => (
@@ -52,6 +57,7 @@ export function Pagination({
         className={styles.rotateArrow}
         onClick={onClickNext}
         disabled={isLastPage}
+        aria-label="next-page"
       >
         {arrow}
       </button>

--- a/app/frontend/src/pages/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/pages/Mogaco/MogacoList.tsx
@@ -49,37 +49,25 @@ export function MogacoList({ currentPage }: MogacoListProp) {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       {mogacoList && mogacoList.length > 0 ? (
         mogacoList.map(
-          ({
-            id,
-            groupId,
-            title,
-            contents,
-            date,
-            maxHumanCount,
-            address,
-            status,
-            group,
-          }) => (
+          ({ id, title, contents, date, address, status, group }) => (
             <MogacoItem
               key={id}
               id={id}
-              title={title}
-              groupId={groupId}
-              contents={contents}
-              maxHumanCount={maxHumanCount}
-              address={address}
-              date={date}
-              status={status}
               group={group}
+              title={title}
+              contents={contents}
+              date={date}
+              address={address}
+              status={status}
             />
           ),
         )
       ) : (
         <EmptyPage />
       )}
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## 설명
- close #444 
- 모각코 리스트 페이지(/mogaco)의 접근성을 개선합니다. (lighthouse 기준 62점 → 95점)
- [노션 개발 일지](https://www.notion.so/ttaerrim/be56a4fcbd3f4fe9a6f29525b492ab0c?p=5e26158dc5254aba9b6bff2d706be07d&pm=s)에 작업 과정을 기록하고 있습니다.

## 완료한 기능 명세
- [x] ARIA 태그 추가 및 수정
- [x] HTML 태그 수정

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/3f9029c0-7a85-47e0-92dd-fadca2da3dbe)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

