### PR TITLE
[Refactor] 모각코 상세 게시글 페이지 접근성 개선

### DIFF
--- a/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/ChatList.tsx
@@ -24,7 +24,7 @@ export function ChatList({
 }: ChatListProps) {
   const prevScrollHeightRef = useRef(0);
   const listElemRef = useRef<HTMLUListElement>(null);
-  const observableRef = useRef<HTMLDivElement | null>(null);
+  const observableRef = useRef<HTMLLIElement | null>(null);
   const exposed = useObserver(observableRef);
 
   useEffect(() => {
@@ -66,7 +66,7 @@ export function ChatList({
 
   return (
     <ul className={styles.chatList} ref={listElemRef}>
-      <div ref={observableRef} />
+      <li ref={observableRef} />
       {chatItems.map((chatItem) => {
         const participantInfo = participants.find(
           (participant) => participant.id === chatItem.user,

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/ChattingFooter.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/ChattingFooter.tsx
@@ -38,6 +38,7 @@ export function ChattingFooter({ userId, sendMessage }: ChattingFooterProps) {
   return (
     <form className={styles.footer} onSubmit={onSubmit}>
       <Textarea
+        aria-label="메시지 입력"
         value={message}
         maxLength={300}
         fullWidth

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/NotificationItem.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/NotificationItem.tsx
@@ -7,7 +7,7 @@ type NotificationItemProps = {
 };
 
 function NotificationItem({ contents }: NotificationItemProps) {
-  return <div className={styles.notification}>{contents}</div>;
+  return <li className={styles.notification}>{contents}</li>;
 }
 
 export const MemorizedNotificationItem = memo(NotificationItem);

--- a/app/frontend/src/components/Sidebar/Contents/Chatting/TalkItem.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Chatting/TalkItem.tsx
@@ -27,7 +27,7 @@ function TalkItem({
     : wrappedDate.format('MM.DD h:mm A');
 
   return (
-    <div className={styles.talkContainer}>
+    <li className={styles.talkContainer}>
       {!isMine && <UserChip username={nickname} profileSrc={profilePicture} />}
       <div className={`${styles.talkContents} ${isMine && styles.isMine}`}>
         {contents}
@@ -35,7 +35,7 @@ function TalkItem({
       <div className={`${styles.datetime} ${isMine && styles.isMine}`}>
         {dateString}
       </div>
-    </div>
+    </li>
   );
 }
 

--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -26,11 +26,7 @@ export const closed = style({
   transform: 'translateX(calc(-100% + 2.4rem))',
 });
 
-export const flip = style({
-  transform: 'rotate(180deg)',
-});
-
-export const panel = style({
+const panel = style({
   display: 'flex',
   flexGrow: '1',
   maxWidth: 'calc(100% - 2.4rem)',
@@ -38,6 +34,25 @@ export const panel = style({
   borderRight: `1px solid ${vars.color.grayscale100}`,
   background: vars.color.grayscaleWhite,
 });
+
+export const emptyPanel = style([
+  panel,
+  {
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: vars.color.grayscale50,
+  },
+]);
+
+export const flip = style({
+  transform: 'rotate(180deg)',
+});
+
+export const hidden = style({
+  visibility: 'hidden',
+});
+
+export { panel };
 
 export const wrapper = style({
   display: 'flex',

--- a/app/frontend/src/components/Sidebar/index.tsx
+++ b/app/frontend/src/components/Sidebar/index.tsx
@@ -18,6 +18,7 @@ export function Sidebar({ closed, toggleClosed, children }: SidebarProps) {
         className={styles.closeButton}
         onClick={toggleClosed}
         data-cy="sidebar-button"
+        aria-label={closed ? '사이드바 열기' : '사이드바 닫기'}
       >
         <ArrowLeft
           className={closed ? styles.flip : ''}

--- a/app/frontend/src/components/Sidebar/index.tsx
+++ b/app/frontend/src/components/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import { ReactComponent as ArrowLeft } from '@/assets/icons/arrow_left.svg';
+import { ReactComponent as Morak } from '@/assets/icons/morak.svg';
 import { vars } from '@/styles';
 
 import * as styles from './index.css';
@@ -12,7 +13,15 @@ type SidebarProps = {
 export function Sidebar({ closed, toggleClosed, children }: SidebarProps) {
   return (
     <div className={`${styles.wrapper} ${closed && styles.closed}`}>
-      <div className={styles.panel}>{children}</div>
+      {closed ? (
+        <div className={styles.emptyPanel}>
+          <Morak width={64} height={64} />
+        </div>
+      ) : (
+        <div className={`${styles.panel} ${closed && styles.hidden}`}>
+          {children}
+        </div>
+      )}
       <button
         type="button"
         className={styles.closeButton}

--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -56,6 +56,7 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
             participantsShown ? styles.shown : ''
           }`}
           onClick={toggleParticipantsShown}
+          aria-label="toggle-participants"
         >
           <ArrowDown width={16} height={16} fill={vars.color.grayscaleBlack} />
         </button>

--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -56,7 +56,9 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
             participantsShown ? styles.shown : ''
           }`}
           onClick={toggleParticipantsShown}
-          aria-label="toggle-participants"
+          aria-label={
+            participantsShown ? '참석자 목록 닫기' : '참석자 목록 열기'
+          }
         >
           <ArrowDown width={16} height={16} fill={vars.color.grayscaleBlack} />
         </button>

--- a/app/frontend/src/pages/MogacoDetail/index.tsx
+++ b/app/frontend/src/pages/MogacoDetail/index.tsx
@@ -51,7 +51,7 @@ export function MogacoDetailPage() {
         title={mogacoData.title}
         participants={mogacoData.participants}
       />
-      <div className={styles.container}>
+      <main className={styles.container}>
         <DetailHeader id={id} openChatting={openChatting} />
         <DetailInfo
           id={id}
@@ -60,7 +60,7 @@ export function MogacoDetailPage() {
         />
         <div className={styles.contents}>{mogacoData.contents}</div>
         <Divider />
-      </div>
+      </main>
     </div>
   );
 }

--- a/app/frontend/src/pages/MogacoPost/Controller/PostContents.tsx
+++ b/app/frontend/src/pages/MogacoPost/Controller/PostContents.tsx
@@ -24,6 +24,7 @@ export function PostContents({ control }: PostContentsProps) {
       render={({ field: { onChange, value }, fieldState: { error } }) => (
         <Textarea
           label={MOGACO_POST.CONTENTS.LABEL}
+          aria-label="내용"
           placeholder={MOGACO_POST.CONTENTS.REQUIRED}
           rows={MOGACO_POST.CONTENTS.ROWS}
           maxLength={MOGACO_POST.CONTENTS.MAX_LENGTH}


### PR DESCRIPTION
## 설명
- close #447
- 모각코 상세 게시글 페이지의 접근성을 개선했습니다. (lighthouse 기준 83점 -> 96점)
- 사이드바가 닫혀있을 때 `visibility: hidden` 속성을 추가하여 포커싱되지 않게 만들었습니다.

## 완료한 기능 명세
- [x] ARIA 태그 추가
- [x] 기존 HTML 태그 교체
- [x] 사이드바 닫힘 시 hidden 처리

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/35591f11-d19b-4707-8187-45863292e676)
![GIF 2023-12-13 오후 5-42-21](https://github.com/boostcampwm2023/web17_morak/assets/50646827/bf753bae-68c8-4a00-956c-d243bd1951c8)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

