### PR TITLE
[Refactor] 헤더 컴포넌트 스크린 리더 & 키보드 접근성 개선

### DIFF
--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -10,12 +10,12 @@ export function Header() {
   const { SIDE_MENU } = useMenu();
   const { pathname } = useLocation();
 
-  const { onClickMenu } = useClickMenu();
+  const { onClickMenu, onEnterMenu } = useClickMenu();
 
   return (
     <header className={styles.container}>
       <div className={styles.header}>
-        <NavLink to="/" className={styles.title}>
+        <NavLink to="/" className={styles.title} aria-label="홈으로">
           <Logo className={styles.logo} />
           <div className={styles.logoTitle}>morak</div>
         </NavLink>
@@ -23,9 +23,10 @@ export function Header() {
           <ul className={styles.sideMenu} role="menubar" data-cy="header-menu">
             {SIDE_MENU.map((menu) => (
               <li
+                tabIndex={0}
                 key={menu.pathname}
                 onClick={() => onClickMenu(menu.pathname)}
-                onKeyDown={() => onClickMenu(menu.pathname)}
+                onKeyDown={(e) => onEnterMenu(e, menu.pathname)}
                 className={`${styles.sideMenuButton} ${
                   pathname === `/${menu.pathname}` ? styles.active : ''
                 }`}

--- a/app/frontend/src/components/Header/index.tsx
+++ b/app/frontend/src/components/Header/index.tsx
@@ -31,7 +31,7 @@ export function Header() {
                   pathname === `/${menu.pathname}` ? styles.active : ''
                 }`}
                 role="menuitem"
-                aria-label={menu.pathname}
+                aria-label={menu.ariaLabel}
                 data-cy="header-menu-item"
               >
                 {menu.value}

--- a/app/frontend/src/components/Header/useClickMenu.ts
+++ b/app/frontend/src/components/Header/useClickMenu.ts
@@ -17,5 +17,11 @@ export const useClickMenu = () => {
     }
   };
 
-  return { onClickMenu };
+  const onEnterMenu = (e: React.KeyboardEvent, path: string) => {
+    if (e.key === 'Enter') {
+      onClickMenu(path);
+    }
+  };
+
+  return { onClickMenu, onEnterMenu };
 };

--- a/app/frontend/src/components/Header/useMenu.tsx
+++ b/app/frontend/src/components/Header/useMenu.tsx
@@ -4,14 +4,15 @@ import * as styles from './index.css';
 
 export const useMenu = () => {
   const SIDE_MENU = [
-    { pathname: 'mogaco', value: 'mogaco' },
-    { pathname: 'calendar', value: 'calendar' },
-    { pathname: 'map', value: 'map' },
+    { pathname: 'mogaco', value: 'mogaco', ariaLabel: '모각코' },
+    { pathname: 'calendar', value: 'calendar', ariaLabel: '달력' },
+    { pathname: 'map', value: 'map', ariaLabel: '지도' },
     {
       pathname: 'profile',
       value: (
         <Profile width={24} height={24} className={styles.profileButton} />
       ),
+      ariaLabel: '프로필',
     },
   ];
 


### PR DESCRIPTION
## 설명
- #460
- 스크린 리더와 키보드를 통해 헤더의 각 메뉴에 접근할 수 있도록 합니다.

## 완료한 기능 명세
- [x] 헤더의 각 메뉴에 `tabindex=0` 속성 추가
- [x] aria-label을 한글로 변경
- [x] useClickMenu 훅에 onEnterMenu() 추가, 기존 onKeyDown 핸들러 변경

### 동작 화면 (음성 포함)
https://github.com/boostcampwm2023/web17_morak/assets/50646827/3e96ffd9-cf7f-498b-874f-53a53df6facf


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

