### PR TITLE
[Refactor] 모각코 리스트 페이지 스크린 리더 & 키보드 접근성 개선

### DIFF
--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -37,24 +37,27 @@ export function MogacoItem({
 
   return (
     <NavLink to={`/mogaco/${id}`} className={styles.container}>
-      <div className={styles.titleArea}>
+      <h2 className={styles.titleArea}>
         {MogacoLabel}
         <div className={styles.title}>{title}</div>
-      </div>
-      <div className={styles.group}>{groupTitle}</div>
+      </h2>
+      <span className={styles.group}>{groupTitle}</span>
       <div className={styles.content}>
-        <div className={styles.detail}>{contents}</div>
+        <p className={styles.detail}>{contents}</p>
         <div className={styles.info}>
-          <div className={styles.infoContent}>
+          <address className={styles.infoContent}>
             <Map className={styles.icon} width={20} height={20} />
-            <div className={styles.infoText}>{address}</div>
-          </div>
-          <div className={styles.infoContent}>
+            <span className={styles.infoText}>{address}</span>
+          </address>
+          <time
+            className={styles.infoContent}
+            dateTime={dayjs(date).format('YYYY-MM-DD HH:MM')}
+          >
             <Calendar className={styles.icon} width={20} height={20} />
-            <div className={styles.infoText}>
+            <span className={styles.infoText}>
               {dayjs(date).format('YYYY/MM/DD HH:mm~')}
-            </div>
-          </div>
+            </span>
+          </time>
         </div>
       </div>
     </NavLink>

--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -36,11 +36,15 @@ export function MogacoItem({
   );
 
   return (
-    <NavLink to={`/mogaco/${id}`} className={styles.container}>
-      <h2 className={styles.titleArea}>
+    <NavLink
+      to={`/mogaco/${id}`}
+      className={styles.container}
+      aria-label={`${title}, ${status}`}
+    >
+      <div className={styles.titleArea}>
         {MogacoLabel}
-        <div className={styles.title}>{title}</div>
-      </h2>
+        <h2 className={styles.title}>{title}</h2>
+      </div>
       <span className={styles.group}>{groupTitle}</span>
       <div className={styles.content}>
         <p className={styles.detail}>{contents}</p>

--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -55,7 +55,7 @@ export function MogacoItem({
           >
             <Calendar className={styles.icon} width={20} height={20} />
             <span className={styles.infoText}>
-              {dayjs(date).format('YYYY/MM/DD HH:mm~')}
+              {dayjs(date).format('YYYY-MM-DD HH:mm~')}
             </span>
           </time>
         </div>

--- a/app/frontend/src/pages/Mogaco/MogacoList.tsx
+++ b/app/frontend/src/pages/Mogaco/MogacoList.tsx
@@ -49,25 +49,26 @@ export function MogacoList({ currentPage }: MogacoListProp) {
   }
 
   return (
-    <main className={styles.container}>
+    <ul className={styles.container}>
       {mogacoList && mogacoList.length > 0 ? (
         mogacoList.map(
           ({ id, title, contents, date, address, status, group }) => (
-            <MogacoItem
-              key={id}
-              id={id}
-              group={group}
-              title={title}
-              contents={contents}
-              date={date}
-              address={address}
-              status={status}
-            />
+            <li key={id}>
+              <MogacoItem
+                id={id}
+                group={group}
+                title={title}
+                contents={contents}
+                date={date}
+                address={address}
+                status={status}
+              />
+            </li>
           ),
         )
       ) : (
         <EmptyPage />
       )}
-    </main>
+    </ul>
   );
 }

--- a/app/frontend/src/pages/Mogaco/index.tsx
+++ b/app/frontend/src/pages/Mogaco/index.tsx
@@ -21,7 +21,7 @@ export function MogacoPage() {
   const maxPage = Math.floor((allMogacoList?.length || 0) / PAGE_UNIT + 1);
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <MogacoListHeader />
       <MogacoList currentPage={currentPage} />
       {mogacoList?.length !== 0 && (
@@ -34,6 +34,6 @@ export function MogacoPage() {
           onClickPrev={onClickPrev}
         />
       )}
-    </div>
+    </main>
   );
 }

--- a/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
+++ b/app/frontend/src/pages/MogacoDetail/DetailInfo.tsx
@@ -73,14 +73,17 @@ export function DetailInfo({ id, latitude, longitude }: DetailInfoProps) {
           />
         ))}
       </div>
-      <div className={styles.infoItem}>
+      <time
+        className={styles.infoItem}
+        dateTime={dayjs(mogacoData.date).format('YYYY-MM-DD HH:MM')}
+      >
         <Calendar width={24} height={24} fill={vars.color.grayscale200} />
-        <span>{dayjs(mogacoData.date).format('YYYY/MM/DD HH:mm~')}</span>
-      </div>
-      <div className={styles.infoItem}>
+        <span>{dayjs(mogacoData.date).format('YYYY-MM-DD HH:MM~')}</span>
+      </time>
+      <address className={styles.infoItem}>
         <Map width={24} height={24} fill={vars.color.grayscale200} />
         <span>{mogacoData.address}</span>
-      </div>
+      </address>
       <img
         className={styles.map}
         src={staticMapURL}

--- a/packages/morak-ui/src/components/Pagination/index.tsx
+++ b/packages/morak-ui/src/components/Pagination/index.tsx
@@ -24,43 +24,52 @@ export function Pagination({
 }: PaginationProps) {
   const [start, end] = get10UnitRange(currentPage);
   const lastPageNum = pageCount ? Math.min(end, pageCount) : end;
-  const array = createRangeArray(start, lastPageNum);
+  const pageNumbers = createRangeArray(start, lastPageNum);
   const arrow = <Arrow width={16} height={16} fill={grayscale200} />;
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === lastPageNum;
 
   return (
-    <div className={`${styles.container} ${className}`}>
-      <button
-        type="button"
-        onClick={onClickPrev}
-        disabled={isFirstPage}
-        aria-label="prev-page"
-      >
-        {arrow}
-      </button>
-      {array.map((page) => (
-        <button
-          onClick={onClickItem}
-          className={`${styles.page} ${
-            currentPage === page ? styles.current : ''
-          }`}
-          type="button"
-          key={page}
-          value={page}
-        >
-          {page}
-        </button>
-      ))}
-      <button
-        type="button"
-        className={styles.rotateArrow}
-        onClick={onClickNext}
-        disabled={isLastPage}
-        aria-label="next-page"
-      >
-        {arrow}
-      </button>
-    </div>
+    <nav role="navigation" aria-label="페이지 선택">
+      <ul className={`${styles.container} ${className}`}>
+        <li>
+          <button
+            type="button"
+            onClick={onClickPrev}
+            disabled={isFirstPage}
+            aria-label="이전 페이지"
+          >
+            {arrow}
+          </button>
+        </li>
+        {pageNumbers.map((page: number) => (
+          <li key={page}>
+            <button
+              onClick={onClickItem}
+              className={`${styles.page} ${
+                currentPage === page ? styles.current : ''
+              }`}
+              type="button"
+              value={page}
+              aria-current={currentPage === page}
+              aria-label={`${page} 페이지`}
+            >
+              {page}
+            </button>
+          </li>
+        ))}
+        <li>
+          <button
+            type="button"
+            className={styles.rotateArrow}
+            onClick={onClickNext}
+            disabled={isLastPage}
+            aria-label="다음 페이지"
+          >
+            {arrow}
+          </button>
+        </li>
+      </ul>
+    </nav>
   );
 }


### PR DESCRIPTION
## 설명
- close #461 
- 모각코 리스트 페이지의 스크린 리더 및 키보드 접근성을 개선합니다.

## 완료한 기능 명세
- [x] 시맨틱 태그 적용
- [x] 날짜 형식 변경 (날짜 구분자 '/' -> '-') (스크린 리더에서 날짜로 인식하여 읽기 위함)
- [x] 페이지네이션 버튼별 aria-label 속성 추가
- [x] 각 모각코 아이템마다 aria-label에 요약 정보(제목 및 모집상태) 추가

### 동작 화면 (음성 포함)
https://github.com/boostcampwm2023/web17_morak/assets/50646827/92da6c86-9f16-4f3b-85f1-961c515843b2

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

