### PR TITLE
[Test] 모각코, 그룹 모집 필터링, 오류 처리 테스트

### DIFF
--- a/app/backend/src/groups/groups.repository.spec.ts
+++ b/app/backend/src/groups/groups.repository.spec.ts
@@ -3,6 +3,7 @@ import { GroupsRepository } from './groups.repository';
 import { PrismaService } from 'prisma/prisma.service';
 import { CreateGroupsDto } from './dto/create-groups.dto';
 import { Member } from '@prisma/client';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 describe('GroupsRepository', () => {
   let repository: GroupsRepository;
@@ -25,6 +26,7 @@ describe('GroupsRepository', () => {
               findUnique: jest.fn(),
               create: jest.fn(),
               delete: jest.fn(),
+              count: jest.fn(),
             },
           },
         },
@@ -35,13 +37,22 @@ describe('GroupsRepository', () => {
     prismaService = module.get<PrismaService>(PrismaService);
   });
 
+  const mockMember: Member = {
+    id: BigInt(1),
+    providerId: '11111122222222',
+    email: 'morak@gmail.com',
+    nickname: 'morak morak',
+    profilePicture: 'morak morak.jpg',
+    socialType: 'google',
+    createdAt: new Date(),
+  };
+
   describe('getAllGroups', () => {
     it('모든 그룹을 반환해야 함', async () => {
-      const expectedGroups = [
-        { id: BigInt(1), title: '부스트캠프 웹·모바일 8기', membersCount: 212 },
-        { id: BigInt(2), title: '부스트캠프 웹·모바일 9기', membersCount: 187 },
-      ];
+      const expectedGroups = [{ id: BigInt(1), title: '부스트캠프 웹·모바일 8기', membersCount: 212 }];
+      const groupId = 212;
       jest.spyOn(prismaService.group, 'findMany').mockResolvedValue(expectedGroups);
+      jest.spyOn(prismaService.groupToUser, 'count').mockResolvedValue(groupId);
 
       const result = await repository.getAllGroups();
 
@@ -96,15 +107,6 @@ describe('GroupsRepository', () => {
   describe('joinGroup', () => {
     it('그룹에 참여해야 함', async () => {
       const groupId = 1;
-      const member: Member = {
-        id: BigInt(1),
-        providerId: '11111122222222',
-        email: 'morak@gmail.com',
-        nickname: 'morak morak',
-        profilePicture: 'morak morak.jpg',
-        socialType: 'google',
-        createdAt: new Date(),
-      };
 
       jest.spyOn(prismaService.group, 'findUnique').mockResolvedValue({
         id: BigInt(1),
@@ -113,33 +115,43 @@ describe('GroupsRepository', () => {
 
       jest.spyOn(prismaService.groupToUser, 'create').mockResolvedValue({
         groupId: BigInt(1),
-        userId: member.id,
+        userId: mockMember.id,
       });
 
-      await repository.joinGroup(groupId, member);
+      await repository.joinGroup(groupId, mockMember);
 
       // 231204 ldhbenecia | 해당 함수가 특정 인자와 함께 호출되었는지 여부를 확인
       expect(prismaService.groupToUser.create).toHaveBeenCalledWith({
         data: {
           groupId: BigInt(1),
-          userId: member.id,
+          userId: mockMember.id,
         },
       });
+    });
+
+    it('가입할 그룹이 없는 경우 NotFoundException 발생', async () => {
+      jest.spyOn(prismaService.group, 'findUnique').mockResolvedValueOnce(null);
+
+      await expect(repository.joinGroup(1, mockMember)).rejects.toThrowError(NotFoundException);
+    });
+
+    it('그룹에 이미 가입한 멤버가 가입 요청을 하면 Forbidden 발생', async () => {
+      jest.spyOn(prismaService.group, 'findUnique').mockResolvedValue({
+        id: BigInt(1),
+        title: '부스트캠프 웹·모바일 8기',
+      });
+      jest.spyOn(prismaService.groupToUser, 'findUnique').mockResolvedValueOnce({
+        groupId: BigInt(1),
+        userId: mockMember.id,
+      });
+
+      await expect(repository.joinGroup(1, mockMember)).rejects.toThrowError(ForbiddenException);
     });
   });
 
   describe('leaveGroup', () => {
     it('그룹 탈퇴를 해야 함', async () => {
       const groupId = 1;
-      const member: Member = {
-        id: BigInt(1),
-        providerId: '11111122222222',
-        email: 'morak@gmail.com',
-        nickname: 'morak morak',
-        profilePicture: 'morak morak.jpg',
-        socialType: 'google',
-        createdAt: new Date(),
-      };
 
       jest.spyOn(prismaService.group, 'findUnique').mockResolvedValue({
         id: BigInt(1),
@@ -148,21 +160,21 @@ describe('GroupsRepository', () => {
 
       jest.spyOn(prismaService.groupToUser, 'findUnique').mockResolvedValue({
         groupId: BigInt(1),
-        userId: member.id,
+        userId: mockMember.id,
       });
 
       jest.spyOn(prismaService.groupToUser, 'delete').mockResolvedValue({
         groupId: BigInt(1),
-        userId: member.id,
+        userId: mockMember.id,
       });
 
-      await repository.leaveGroup(groupId, member);
+      await repository.leaveGroup(groupId, mockMember);
 
       expect(prismaService.groupToUser.findUnique).toHaveBeenCalledWith({
         where: {
           groupId_userId: {
             groupId: groupId,
-            userId: member.id,
+            userId: mockMember.id,
           },
         },
       });
@@ -171,10 +183,22 @@ describe('GroupsRepository', () => {
         where: {
           groupId_userId: {
             groupId: groupId,
-            userId: member.id,
+            userId: mockMember.id,
           },
         },
       });
+    });
+
+    it('탈퇴할 그룹이 없는 경우 NotFoundException 발생', async () => {
+      jest.spyOn(prismaService.group, 'findUnique').mockResolvedValueOnce(null);
+
+      await expect(repository.leaveGroup(1, mockMember)).rejects.toThrowError(NotFoundException);
+    });
+
+    it('해당 멤버가 그룹에 없는데 탈퇴 요청을 할 경우 NotFoundException 발생', async () => {
+      jest.spyOn(prismaService.groupToUser, 'findUnique').mockResolvedValueOnce(null);
+
+      await expect(repository.leaveGroup(1, mockMember)).rejects.toThrowError(NotFoundException);
     });
   });
 

--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.spec.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.spec.ts
@@ -280,6 +280,32 @@ describe('MogacoRepository', () => {
     deletedAt: null,
   };
 
+  describe('updateCompletedMogacos', () => {
+    it('모각코 시간이 지나면 "모집 중"에서 "종료"로 변경해야 함', async () => {
+      const currentDate = new Date();
+      const mogacosMock = [
+        { id: 1, date: new Date(currentDate.getTime() - 1000), status: '모집 중' },
+        { id: 2, date: new Date(currentDate.getTime() + 1000), status: '종료' },
+      ];
+
+      // findMany 메서드를 Jest의 Mock으로 형변환, Prisma의 Mock이 Jest Mock이 아니기 때문에 타입 캐스팅
+      (prismaService.mogaco.findMany as jest.Mock).mockResolvedValue(mogacosMock);
+
+      await repository['updateCompletedMogacos'](mogacosMock);
+
+      expect(prismaService.mogaco.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: [1],
+          },
+        },
+        data: {
+          status: MogacoStatus.COMPLETED,
+        },
+      });
+    });
+  });
+
   describe('getMogaco', () => {
     it('가입한 그룹의 모든 모각코 조회해야 함', async () => {
       jest.spyOn(prismaService.mogaco, 'findMany').mockResolvedValueOnce(mockResult);


### PR DESCRIPTION
## 설명
- close #474 

## 완료한 기능 명세
- [x] 모각코 모집 필터링 테스트 및 404 오류 구현
- [x] 에러 처리 구현

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/bc6ad70d-ca4d-45c8-81b4-21450c2787fb)

![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/390076c8-4c29-47a5-9f07-a6e56a8ca4cf)

### 첫 커버리지 상태
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/8ff89215-b896-4e33-b2fc-beeaff1c749b)


### 모집 필터링, 오류처리 후 커버리지
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/5a6f5eb4-cd42-431a-ae96-bf02f11d6d84)


### 그룹 오류처리까지 한 이후 커버리지
![image](https://github.com/boostcampwm2023/web17_morak/assets/77393976/fc2daa41-f9af-4947-8978-db6c40957bba)




## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

