### PR TITLE
[Fix] 채팅 UI가 닫혀있을 때 동적 데이터 페칭 버그 수정

### DIFF
--- a/app/frontend/src/components/Sidebar/index.css.ts
+++ b/app/frontend/src/components/Sidebar/index.css.ts
@@ -29,6 +29,7 @@ export const closed = style({
 const panel = style({
   display: 'flex',
   flexGrow: '1',
+  zIndex: 10,
   maxWidth: 'calc(100% - 2.4rem)',
   height: '100%',
   borderRight: `1px solid ${vars.color.grayscale100}`,
@@ -38,8 +39,11 @@ const panel = style({
 export const emptyPanel = style([
   panel,
   {
+    position: 'absolute',
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 5,
+    width: '100%',
     background: vars.color.grayscale50,
   },
 ]);

--- a/app/frontend/src/components/Sidebar/index.tsx
+++ b/app/frontend/src/components/Sidebar/index.tsx
@@ -13,15 +13,12 @@ type SidebarProps = {
 export function Sidebar({ closed, toggleClosed, children }: SidebarProps) {
   return (
     <div className={`${styles.wrapper} ${closed && styles.closed}`}>
-      {closed ? (
-        <div className={styles.emptyPanel}>
-          <Morak width={64} height={64} />
-        </div>
-      ) : (
-        <div className={`${styles.panel} ${closed && styles.hidden}`}>
-          {children}
-        </div>
-      )}
+      <div className={`${styles.panel} ${closed && styles.hidden}`}>
+        {children}
+      </div>
+      <div className={styles.emptyPanel}>
+        <Morak width={64} height={64} />
+      </div>
       <button
         type="button"
         className={styles.closeButton}


### PR DESCRIPTION
## 설명
- close #483
- 사이드바가 닫혀있을 때 채팅 컴포넌트가 마운트되지 않아 실시간 정보 갱신이 안 되는 현상을 수정합니다.

## 완료한 기능 명세
- [x] 사이드바가 닫혀있을 때 실시간 정보 갱신이 안 되는 버그 수정

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

