### PR TITLE
[Refactor] 모각코 상태에 따라 라벨 색상 변경

### DIFF
--- a/app/frontend/src/components/MogacoItem/index.css.ts
+++ b/app/frontend/src/components/MogacoItem/index.css.ts
@@ -109,6 +109,6 @@ export const title = style([
 export const titleArea = style({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.4rem',
+  gap: '0.8rem',
   width: '100%',
 });

--- a/app/frontend/src/components/MogacoItem/index.tsx
+++ b/app/frontend/src/components/MogacoItem/index.tsx
@@ -30,7 +30,11 @@ export function MogacoItem({
   status,
 }: MogacoProps) {
   const MogacoLabel = (
-    <Label theme="primary" shape="fill" disabled={status === '마감'}>
+    <Label
+      theme={status === '모집 중' ? 'primary' : 'danger'}
+      shape="fill"
+      disabled={status === '모집 마감'}
+    >
       {status}
     </Label>
   );

--- a/app/frontend/src/components/Sidebar/Contents/Mogaco/TitleWrapper.tsx
+++ b/app/frontend/src/components/Sidebar/Contents/Mogaco/TitleWrapper.tsx
@@ -9,7 +9,11 @@ export function TitleWrapper({
 }: Pick<ResponseMogacoDto, 'title' | 'status'>) {
   return (
     <div className={styles.titleWrapper}>
-      <Label theme="primary" shape="fill">
+      <Label
+        theme={status === '모집 중' ? 'primary' : 'danger'}
+        shape="fill"
+        disabled={status === '모집 마감'}
+      >
         {status}
       </Label>
       <span className={styles.title}>{title}</span>

--- a/packages/morak-ui/src/components/Label/index.css.ts
+++ b/packages/morak-ui/src/components/Label/index.css.ts
@@ -6,10 +6,11 @@ const { grayscale50, morakGreen, morakRed, grayscale200 } = vars.color;
 export const container = recipe({
   base: {
     display: 'inline-flex',
+    flexShrink: 0,
     justifyContent: 'center',
     alignItems: 'center',
-    minWidth: '3.5rem',
-    padding: '0.4rem 1.5rem',
+    minWidth: '3.6rem',
+    padding: '0.4rem 1.4rem',
     borderRadius: '100rem',
     whiteSpace: 'pre',
   },


### PR DESCRIPTION
## 설명
- close #493 
- 모각코 아이템, 모각코 정보 사이드바에서 라벨 색상을 해당 모각코의 모집 상태에 따라 변경합니다.

## 완료한 기능 명세
- [x] 모각코 아이템 라벨 색상 변경
- [x] 사이드바 모각코 정보 라벨 색상 변경
- [x] 라벨 스타일 미세 수정

### 스크린샷
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/6af6f7f7-bf02-482d-b9e4-54d4a155788c)
![image](https://github.com/boostcampwm2023/web17_morak/assets/50646827/035664fc-3417-448d-b69a-e72637422320)

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

