### PR TITLE
[Feat] 내가 참여한 모각코 조회 시 삭제된 모각코 제외 반환

### DIFF
--- a/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
+++ b/app/backend/src/mogaco-boards/mogaco-boards.repository.ts
@@ -179,6 +179,9 @@ export class MogacoRepository {
     const mogacos = await this.prisma.participant.findMany({
       where: {
         userId: member.id,
+        mogaco: {
+          deletedAt: null,
+        },
       },
       include: {
         mogaco: {


### PR DESCRIPTION
## 설명
- close #497 

현재 프로필에서 내가 참여한 모각코 조회시 이미 제거된 모각코임에도 리스트에 표시 됨
이 현상을 제거하기 위해 삭제된 모각코는 반환 안함

## 완료한 기능 명세
- [x] 내가 참여한 모각코 조회 시 삭제된 모각코 제외 반환

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

