### PR TITLE
[Feat] 특정 그룹 정보 반환 API 구현

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -26,7 +26,19 @@ export class GroupsController {
     return this.groupsService.getAllGroups();
   }
 
-  @Get('/:id/groups')
+  @Get('/:id')
+  @ApiOperation({
+    summary: '특정 그룹 정보 조회',
+    description: '특정 그룹의 정보를 조회합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [GroupsWithMemberCountDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Group with id not found' })
+  async getGroups(@Param('id', ParseIntPipe) id: number): Promise<Group & { membersCount: number }> {
+    return this.groupsService.getGroups(id);
+  }
+
+  @Get('/:id/members')
   @ApiOperation({
     summary: '특정 그룹 소속 인원 조회',
     description: '특정 그룹의 Id 값으로 해당 그룹의 소속 인원을 조회합니다.',
@@ -40,8 +52,8 @@ export class GroupsController {
 
   @Post('/')
   @ApiOperation({
-    summary: '그룹 개설',
-    description: '새로운 모각코를 개설합니다.',
+    summary: '그룹 생성',
+    description: '새로운 그룹을 생성합니다.',
   })
   @ApiBody({ type: CreateGroupsDto })
   @ApiResponse({ status: 201, description: 'Successfully created', type: CreateGroupsDto })

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -27,6 +27,21 @@ export class GroupsRepository {
     return Promise.all(groupPromises);
   }
 
+  async getGroups(id: number): Promise<Group & { membersCount: number }> {
+    const group = await this.prisma.group.findUnique({
+      where: {
+        id: id,
+      },
+    });
+
+    if (!group) {
+      throw new NotFoundException(`Group with ID ${id} not found.`);
+    }
+
+    const membersCount = await this.getGroupMembersCount(id);
+    return { ...group, membersCount };
+  }
+
   async getAllMembersOfGroup(groupId: number): Promise<MemberInformationDto[]> {
     const groupToUsers = await this.prisma.groupToUser.findMany({
       where: {

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -12,6 +12,10 @@ export class GroupsService {
     return this.groupsRepository.getAllGroups();
   }
 
+  async getGroups(id: number): Promise<Group & { membersCount: number }> {
+    return this.groupsRepository.getGroups(id);
+  }
+
   async getAllMembersOfGroup(id: number): Promise<MemberInformationDto[]> {
     return this.groupsRepository.getAllMembersOfGroup(id);
   }


### PR DESCRIPTION
## 설명
- close #510 
특정 그룹 정보 반환 API 구현

## 완료한 기능 명세
- [x] 특정 그룹에 대한 정보 반환 API를 추가 구현
- [x] 기존의 /:id/groups -> /:id/members로 엔드포인트 변경

### 스크린샷
<img width="528" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/94c2d6e4-a733-4bc9-a994-e7e888bd17b6">

- 기존의 http://localhost:8080/groups/1/groups 엔드 포인트를 http://localhost:8080/groups/1/members로 변경
<img width="670" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/ab9295be-7359-42a4-89ab-3c3d31d9e0e1">

<img width="739" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/2686fa61-0c10-47d8-b61f-3b004324f858">



## 리뷰 요청 사항
@js43o 
@LEEJW1953 
@ttaerrim 

기존의 API 엔드포인트가 변경되었으니 확인 후 수정 부탁드립니다.

