### PR TITLE
[Feat] 그룹 생성 시 그룹장, 그룹 타입 id 반환

### DIFF
--- a/app/backend/src/groups/dto/create-groups.dto.ts
+++ b/app/backend/src/groups/dto/create-groups.dto.ts
@@ -1,9 +1,12 @@
 import { RequestGroupsDto } from '@morak/apitype/dto/request/groups';
-import { IsNotEmpty } from 'class-validator';
+import { IsInt, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateGroupsDto implements RequestGroupsDto {
   @ApiProperty({ description: 'Title of the Group', example: '부스트캠프 웹·모바일 8기' })
   @IsNotEmpty()
   title: string;
+
+  @IsInt()
+  groupTypeId: number;
 }

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -58,8 +58,8 @@ export class GroupsController {
   @ApiBody({ type: CreateGroupsDto })
   @ApiResponse({ status: 201, description: 'Successfully created', type: CreateGroupsDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async createGroups(@Body() createGroupsDto: CreateGroupsDto): Promise<Group> {
-    return this.groupsService.createGroups(createGroupsDto);
+  async createGroups(@Body() createGroupsDto: CreateGroupsDto, @GetUser() member: Member): Promise<Group> {
+    return this.groupsService.createGroups(createGroupsDto, member);
   }
 
   @Post('/:id/join')

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -60,13 +60,17 @@ export class GroupsRepository {
     }));
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto): Promise<Group> {
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<Group> {
     try {
-      const { title } = createGroupsDto;
+      const { title, groupTypeId } = createGroupsDto;
 
       const group = await this.prisma.group.create({
         data: {
-          title,
+          title: title,
+          groupTypeId: groupTypeId,
+          member: {
+            connect: { id: Number(member.id) },
+          },
         },
       });
 

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -20,8 +20,8 @@ export class GroupsService {
     return this.groupsRepository.getAllMembersOfGroup(id);
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto): Promise<Group> {
-    return this.groupsRepository.createGroups(createGroupsDto);
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<Group> {
+    return this.groupsRepository.createGroups(createGroupsDto, member);
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {

--- a/packages/apitype/dto/request/groups.ts
+++ b/packages/apitype/dto/request/groups.ts
@@ -1,3 +1,4 @@
 export interface RequestGroupsDto {
   title: string;
+  groupTypeId: number;
 }

--- a/packages/apitype/dto/response/groups.ts
+++ b/packages/apitype/dto/response/groups.ts
@@ -3,6 +3,8 @@ import { Bigint } from "../type";
 export interface ResponseGroupsDto {
   id: Bigint;
   title: string;
+  groupOwnerId: Bigint;
+  groupTypeId: number;
 }
 
 export interface ResponseGroupsWithMemberCountDto {


### PR DESCRIPTION
## 설명
- close #518 

## 완료한 기능 명세
- [x] 그룹을 생성할 때 그룹장과 그룹 타입 아이디를 반환

### 스크린샷
<img width="633" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/3ee3d025-3c92-4343-9105-373fed81d4db">



## 리뷰 요청 사항
@ccxz84 
@ttaerrim 
@js43o 
@LEEJW1953 

현재 그룹 타입 아이디 값을 숫자 값으로 받는데 숫자 값별로 어떠한 경우를 처리하는지에 대한 결정이 필요합니다.

