### PR TITLE
[Feat] 그룹 생성 시 GroupAccessCode 생성 및 DB 저장

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GroupsService } from './groups.service';
 import { GetUser } from 'libs/decorators/get-user.decorator';
 import { AtGuard } from 'src/auth/guards/at.guard';
@@ -24,6 +24,20 @@ export class GroupsController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllGroups(): Promise<(Group & { membersCount: number })[]> {
     return this.groupsService.getAllGroups();
+  }
+
+  @Get('/info')
+  @ApiOperation({
+    summary: '승인코드를 사용하여 그룹 정보 추출',
+    description: '승인 코드를 사용하여 특정 그룹 정보를 추출합니다.',
+  })
+  @ApiQuery({ name: 'access-code', description: '참가할 그룹의 승인 코드' })
+  @ApiResponse({ status: 201, description: 'Successfully retrieved group information' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Group not found for the provided access code' })
+  async getGroupByAccessCode(@Query('access_code') accessCode: string): Promise<Group & { membersCount: number }> {
+    return this.groupsService.getGroupByAccessCode(accessCode);
   }
 
   @Get('/:id')

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -34,7 +34,6 @@ export class GroupsController {
   @ApiQuery({ name: 'access-code', description: '참가할 그룹의 승인 코드' })
   @ApiResponse({ status: 201, description: 'Successfully retrieved group information' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Group not found for the provided access code' })
   async getGroupByAccessCode(@Query('access_code') accessCode: string): Promise<Group & { membersCount: number }> {
     return this.groupsService.getGroupByAccessCode(accessCode);
@@ -101,7 +100,6 @@ export class GroupsController {
   @ApiParam({ name: 'id', description: '참가를 취소할 그룹의 Id' })
   @ApiResponse({ status: 200, description: 'Successfully leaved join' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -72,7 +72,10 @@ export class GroupsController {
   @ApiBody({ type: CreateGroupsDto })
   @ApiResponse({ status: 201, description: 'Successfully created', type: CreateGroupsDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async createGroups(@Body() createGroupsDto: CreateGroupsDto, @GetUser() member: Member): Promise<Group> {
+  async createGroups(
+    @Body() createGroupsDto: CreateGroupsDto,
+    @GetUser() member: Member,
+  ): Promise<{ group: Group; accessCode: string }> {
     return this.groupsService.createGroups(createGroupsDto, member);
   }
 

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -28,6 +28,27 @@ export class GroupsRepository {
     return Promise.all(groupPromises);
   }
 
+  async getGroupByAccessCode(accessCode: string): Promise<Group & { membersCount: number }> {
+    const groupAccessCode = await this.prisma.groupAccessCode.findUnique({
+      where: {
+        accessCode: accessCode,
+      },
+      include: {
+        groupAccessCodes: true,
+      },
+    });
+
+    if (!groupAccessCode) {
+      throw new NotFoundException('Group not found for the provided access code');
+    }
+
+    const membersCount = await this.getGroupMembersCount(Number(groupAccessCode.groupId));
+    return {
+      ...groupAccessCode.groupAccessCodes,
+      membersCount,
+    };
+  }
+
   async getGroups(id: number): Promise<Group & { membersCount: number }> {
     const group = await this.prisma.group.findUnique({
       where: {

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -3,6 +3,7 @@ import { PrismaService } from 'prisma/prisma.service';
 import { Group, Member } from '@prisma/client';
 import { MemberInformationDto } from 'src/member/dto/member.dto';
 import { CreateGroupsDto } from './dto/create-groups.dto';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class GroupsRepository {
@@ -71,6 +72,14 @@ export class GroupsRepository {
           member: {
             connect: { id: Number(member.id) },
           },
+        },
+      });
+
+      const accessCode = uuidv4();
+      await this.prisma.groupAccessCode.create({
+        data: {
+          accessCode,
+          groupId: group.id,
         },
       });
 

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -82,7 +82,7 @@ export class GroupsRepository {
     }));
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<Group> {
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<{ group: Group; accessCode: string }> {
     try {
       const { title, groupTypeId } = createGroupsDto;
 
@@ -104,7 +104,9 @@ export class GroupsRepository {
         },
       });
 
-      return group;
+      await this.joinGroup(Number(group.id), member);
+
+      return { group, accessCode };
     } catch (error) {
       throw new Error(`Failed to create group: ${error.message}`);
     }

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -83,33 +83,29 @@ export class GroupsRepository {
   }
 
   async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<{ group: Group; accessCode: string }> {
-    try {
-      const { title, groupTypeId } = createGroupsDto;
+    const { title, groupTypeId } = createGroupsDto;
 
-      const group = await this.prisma.group.create({
-        data: {
-          title: title,
-          groupTypeId: groupTypeId,
-          member: {
-            connect: { id: Number(member.id) },
-          },
+    const group = await this.prisma.group.create({
+      data: {
+        title: title,
+        groupTypeId: groupTypeId,
+        member: {
+          connect: { id: Number(member.id) },
         },
-      });
+      },
+    });
 
-      const accessCode = uuidv4();
-      await this.prisma.groupAccessCode.create({
-        data: {
-          accessCode,
-          groupId: group.id,
-        },
-      });
+    const accessCode = uuidv4();
+    await this.prisma.groupAccessCode.create({
+      data: {
+        accessCode,
+        groupId: group.id,
+      },
+    });
 
-      await this.joinGroup(Number(group.id), member);
+    await this.joinGroup(Number(group.id), member);
 
-      return { group, accessCode };
-    } catch (error) {
-      throw new Error(`Failed to create group: ${error.message}`);
-    }
+    return { group, accessCode };
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -24,7 +24,7 @@ export class GroupsService {
     return this.groupsRepository.getAllMembersOfGroup(id);
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<Group> {
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<{ group: Group; accessCode: string }> {
     return this.groupsRepository.createGroups(createGroupsDto, member);
   }
 

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -12,6 +12,10 @@ export class GroupsService {
     return this.groupsRepository.getAllGroups();
   }
 
+  async getGroupByAccessCode(accessCode: string): Promise<Group & { membersCount: number }> {
+    return this.groupsRepository.getGroupByAccessCode(accessCode);
+  }
+
   async getGroups(id: number): Promise<Group & { membersCount: number }> {
     return this.groupsRepository.getGroups(id);
   }


### PR DESCRIPTION
## 설명
- close #525 

## 완료한 기능 명세
- [x] 그룹 생성 시 GroupAccessCode 생성 및 DB 저장
- [x] Access_Code를 이용하여 그룹에 대한 정보 반환 API 구현
- [x] 그룹 생성 시 해당 그룹 가입 처리
- [x] 그룹 생성 시 해당 승인 코드도 반환

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="809" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/99b817c6-89bf-4494-b566-40800fdaaf4b">

<img width="401" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/fba019ff-e214-4cd7-8b4b-e32d298860f2">

<img width="453" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/41b4a44b-a1b1-4819-b49b-d46f99c3ed2c">

### 액세스 코드를 통한 그룹 정보 반환
<img width="816" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/3819fba2-e130-4146-ad32-c622c625b9c7">

현재 결과 멤버 카운트가 0으로 조회됨
그룹을 생성하고 그룹에 해당 방장이 insert가 되지 않는 현상으로 추정
그룹 생성하고 바로 그룹 가입 처리

<img width="512" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/75e3e3c9-2a59-4497-bc6a-a08e958ad612">

<img width="481" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/31da9006-580a-4329-be9c-dea993eec4aa">

<img width="402" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/b213fadb-0a5a-4c36-a40a-1b5162b243b1">

<img width="825" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/95238f82-1faa-40db-b139-dcf0940d793d">

### 그룹 생성 시 승인 코드도 반환
<img width="662" alt="image" src="https://github.com/boostcampwm2023/web17_morak/assets/77393976/8ae9971b-6d41-4ba0-b5c2-572fb61eb29d">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

@ttaerrim @js43o @LEEJW1953 프론트분들 확인 부탁드립니다.
